### PR TITLE
Post-release version bump to `0.2.0-dev` and GitHub Actions fixes

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,12 @@
-## Release 0.1.0
+## Release 0.2.0 (development release)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov)
+
+## Release 0.1.0 (current release)
 
 ### New features since last release
 

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          base: main
+          base: master
           title: Post-release version bump to `${{ steps.versions.outputs.new_version }}`
           body: >
-            This PR bumps the XIR version from `${{ steps.versions.outputs.old_version }}`
+            This PR bumps the XST version from `${{ steps.versions.outputs.old_version }}`
             to `${{ steps.versions.outputs.new_version }}`.
           commit-message: Bump version to `${{ steps.versions.outputs.new_version }}`
           branch: post-release-version-bump

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          base: main
+          base: master
           title: Pre-release version bump to `${{ steps.versions.outputs.new_version }}`
           body: >
             This PR bumps the XST version from `${{ steps.versions.outputs.old_version }}`

--- a/xanadu_sphinx_theme/_version.py
+++ b/xanadu_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the Xanadu Sphinx Theme version with https://semver.org/
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0-dev"


### PR DESCRIPTION
**Context:**

The first version of the Xanadu Sphinx Theme was just released which means the version and changelog must be updated to accommodate a future 0.2.0 release. The release also revealed an issue with the [Post-Release Version Bump action](https://github.com/XanaduAI/xanadu-sphinx-theme/actions/runs/2248060545):

```
Rebasing commits made to commit '708e1b9c0f709[67](https://github.com/XanaduAI/xanadu-sphinx-theme/runs/6235927946?check_suite_focus=true#step:6:67)e4450b0ca689de1571d123c18' on to base branch 'main'
/usr/bin/git -c protocol.version=2 fetch --no-tags --progress --no-recurse-submodules --unshallow --force origin main:main
fatal: couldn't find remote ref main
Error: The process '/usr/bin/git' failed with exit code 128
```

**Description of the Change:**

* Updated the Python package version to `0.2.0-dev`.
* Added a **Release 0.2.0** section to the changelog.
* Switched the base PR branch in the Post-Release Version Bump action from `main` to `master`.

**Benefits:**
* The repository is ready for contributions towards the 0.2.0 release.
* The Post-Release Version Bump action works as intended.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.