### PR TITLE
Bump Pillow dependency to v9.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==4.5.0
-pillow==9.1.0
+pillow==9.1.1
 sphinx-gallery==0.10.1


### PR DESCRIPTION
**Context:**

Pillow v9.1.0 has a known buffer overflow vulnerability as per [CVE-2022-30595](https://nvd.nist.gov/vuln/detail/CVE-2022-30595).

**Description of the Change:**

* Bumped the Pillow dependency to v9.1.1 in `requirements.txt`.

**Benefits:**

* The XST will have no (known) security vulnerabilities.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.