### PR TITLE
Update globaltoc.html

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,10 +1,17 @@
 ## Release 0.2.0 (development release)
 
+### New features since last release
+
+* Adds the `toc_overview` option, which allows the table of contents to
+  optionally display the project title and a link to the documentation
+  homepage.
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-[Mikhail Andrenkov](https://github.com/Mandrenkov)
+[Mikhail Andrenkov](https://github.com/Mandrenkov),
+[Josh Izaac](https://github.com/josh146).
 
 ## Release 0.1.0 (current release)
 

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,15 @@ The following options customize the appearance of the footer.
 
 ``extra_copyrights``
     List of extra copyright notices to place in the footer.
+    
+Table of contents
+-----------------
+
+The following options customize the table of contents.
+
+``toc_overview``
+    If ``True``, the project name, and a link to the homepage ``index.rst``, is included
+    in the left-hand table of contents.
 
 Style Colours
 -------------

--- a/xanadu_sphinx_theme/globaltoc.html
+++ b/xanadu_sphinx_theme/globaltoc.html
@@ -1,12 +1,14 @@
 
 <div class="sidebar-block">
   <div class="sidebar-toc">
+    {% if toc_overview %}
     <p class="caption">{{ theme_project_nav_name or shorttitle }}</p>
     <ul>
       <li class="caption toctree-l1 {{'current' if pagename == 'index' }}">
         <a class="reference internal" href="{{ pathto('index') }}">Overview</a>
       </li>
     </ul>
+    {% endif %}
     {% set toctree = toctree(maxdepth=1, collapse=True, includehidden=True) %}
     {% if toctree %}
       {{ toctree }}

--- a/xanadu_sphinx_theme/globaltoc.html
+++ b/xanadu_sphinx_theme/globaltoc.html
@@ -1,7 +1,7 @@
 
 <div class="sidebar-block">
   <div class="sidebar-toc">
-    {% if toc_overview %}
+    {% if theme_toc_overview %}
     <p class="caption">{{ theme_project_nav_name or shorttitle }}</p>
     <ul>
       <li class="caption toctree-l1 {{'current' if pagename == 'index' }}">

--- a/xanadu_sphinx_theme/globaltoc.html
+++ b/xanadu_sphinx_theme/globaltoc.html
@@ -9,6 +9,6 @@
       </li>
     </ul>
     {% endif %}
-    {% toctree = toctree(maxdepth=1, collapse=True, includehidden=True) %}
+    {{ toctree(maxdepth=1, collapse=True, includehidden=True) }}
   </div>
 </div>

--- a/xanadu_sphinx_theme/globaltoc.html
+++ b/xanadu_sphinx_theme/globaltoc.html
@@ -2,7 +2,7 @@
 <div class="sidebar-block">
   <div class="sidebar-toc">
     {% if theme_toc_overview %}
-    <p class="caption">{{ theme_project_nav_name or shorttitle }}</p>
+    <p class="caption">{{ theme_navbar_name or shorttitle }}</p>
     <ul>
       <li class="caption toctree-l1 {{'current' if pagename == 'index' }}">
         <a class="reference internal" href="{{ pathto('index') }}">Overview</a>

--- a/xanadu_sphinx_theme/globaltoc.html
+++ b/xanadu_sphinx_theme/globaltoc.html
@@ -9,11 +9,6 @@
       </li>
     </ul>
     {% endif %}
-    {% set toctree = toctree(maxdepth=1, collapse=True, includehidden=True) %}
-    {% if toctree %}
-      {{ toctree }}
-    {% else %}
-      {{ toc }}
-    {% endif %}
+    {% toctree = toctree(maxdepth=1, collapse=True, includehidden=True) %}
   </div>
 </div>

--- a/xanadu_sphinx_theme/globaltoc.html
+++ b/xanadu_sphinx_theme/globaltoc.html
@@ -3,7 +3,7 @@
   <div class="sidebar-toc">
     {% if theme_toc_overview %}
     <p class="caption">{{ theme_navbar_name or shorttitle }}</p>
-    <ul>
+    <ul class="mb-0">
       <li class="caption toctree-l1 {{'current' if pagename == 'index' }}">
         <a class="reference internal" href="{{ pathto('index') }}">Overview</a>
       </li>

--- a/xanadu_sphinx_theme/globaltoc.html
+++ b/xanadu_sphinx_theme/globaltoc.html
@@ -1,6 +1,17 @@
 
 <div class="sidebar-block">
   <div class="sidebar-toc">
-    {{ toctree(maxdepth=1, collapse=True, includehidden=True) }}
+    <p class="caption">{{ theme_project_nav_name or shorttitle }}</p>
+    <ul>
+      <li class="caption toctree-l1 {{'current' if pagename == 'index' }}">
+        <a class="reference internal" href="{{ pathto('index') }}">Overview</a>
+      </li>
+    </ul>
+    {% set toctree = toctree(maxdepth=1, collapse=True, includehidden=True) %}
+    {% if toctree %}
+      {{ toctree }}
+    {% else %}
+      {{ toc }}
+    {% endif %}
   </div>
 </div>

--- a/xanadu_sphinx_theme/theme.conf
+++ b/xanadu_sphinx_theme/theme.conf
@@ -35,6 +35,8 @@ table_header_background_colour =
 text_accent_colour =
 # Colour of the marker beside the current ToC entry.
 toc_marker_colour =
+# Whether to include link to index.rst in the ToC
+toc_overview =
 
 # Google Analytics tracking ID for the website.
 google_analytics_tracking_id =


### PR DESCRIPTION
**Context:** The PL plugins had a customized version of the theme which allowed the plugin name (and a link to `index.rst`) to be included in the global TOC.

**Description of the Change:** Modifies the global TOC to include the project title in the sidebar

**Benefits:** As above.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
