### PR TITLE
Improve stability of Noto Sans import

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,16 @@
-## Release 0.3.0 (development release)
+## Release 0.2.1 (development release)
+
+### Improvements
+
+* [Noto Sans](https://fonts.google.com/noto/specimen/Noto+Sans) is now imported
+  using `@import` instead of `@font-face` for stability reasons.
+  [#9](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/9)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov)
 
 ## Release 0.2.0 (current release)
 
@@ -10,7 +18,7 @@ This release contains contributions from (in alphabetical order):
 
 * Adds the `toc_overview` option, which allows the table of contents to
   optionally display the project title and a link to the documentation
-  homepage.
+  homepage. [#7](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/7)
 
 ### Contributors
 

--- a/xanadu_sphinx_theme/_version.py
+++ b/xanadu_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the Xanadu Sphinx Theme version with https://semver.org/
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.3.0-dev"
+__version__ = "0.2.1-dev"

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -1,11 +1,6 @@
 /* Sphinx Themes
 ----------------------------------------------------------------------------- */
-@font-face {
-  font-family: 'Noto Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/notosans/v12/o-0IIpQlx3QUlC5A4PNr5TRA.woff2) format('woff2');
-}
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap');
 
 body {
   margin: 0;


### PR DESCRIPTION
**Context:**

Every now and then, Sphinx projects which include the Xanadu Sphinx Theme do not render the Noto Sans font correctly. This most likely originates from the use of `@font-face` which is not a recommend way to embed Google Fonts.

For example, the PennyLane Sphinx documentation occasionally renders as

![image](https://user-images.githubusercontent.com/5883774/187778880-80552f63-157f-4185-ba74-a584d1da5230.png)

instead of

![image](https://user-images.githubusercontent.com/5883774/187779009-adaad90a-7466-4a63-aadf-89a754c50bc3.png)

(To easily spot the difference, take a look at the renderings of the "g".)

**Description of the Change:**

* Replaced the `@font-face` directive with an `@import` directive in the CSS file.

**Benefits:**

* Better stability when importing the Noto Sans font.

**Possible Drawbacks:**

* None.

**Related GitHub Issues:**

* None.