### PR TITLE
Fix a bug where sidebars were not properly configured

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,6 +19,8 @@
   - `footer_links` to create columns of links
   - `footer_social` to customize social media icons
   - `footer_tagline` to set the tagline
+  
+* Fixed a bug where the HTML sidebars were not properly configured. [#17](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/17)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,6 +20,8 @@
   - `footer_social` to customize social media icons
   - `footer_tagline` to set the tagline
   
+### Bug fixes
+
 * Fixed a bug where the HTML sidebars were not properly configured. [#17](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/17)
 
 ### Contributors

--- a/README.rst
+++ b/README.rst
@@ -50,17 +50,6 @@ Once installed, simply add or modify the following variables of your Sphinx
 
     html_theme = "xanadu"
 
-.. code-block:: python
-
-    html_sidebars = {
-        "**" : [
-            "searchbox.html",
-            "globaltoc.html",
-        ]
-    }
-
-.. code-block:: python
-
     html_theme_options = {
         "navbar_name": "Example Project",
         "navbar_logo_colour": "#123456",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,15 +96,6 @@ todo_include_todos = False
 # pixels large.
 html_favicon = "_static/favicon.ico"
 
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-html_sidebars = {
-    "**": [
-        "searchbox.html",
-        "globaltoc.html",
-    ]
-}
-
 
 # Xanadu theme options (see theme.conf for more information).
 html_theme_options = {

--- a/xanadu_sphinx_theme/theme.conf
+++ b/xanadu_sphinx_theme/theme.conf
@@ -1,6 +1,7 @@
 [theme]
 inherit = basic
 stylesheet = xanadu.css
+sidebars = globaltoc.html, searchbox.html
 
 [options]
 # Name of the project to appear in the navigation bar.


### PR DESCRIPTION
**Context:** The theme sidebars were not configured, requiring users to configure them manually.

**Description of the Change:** Adds the sidebar templates to the `theme.conf`.

**Benefits:** Users no longer have to specify `html_sidebars` themselves.

**Possible Drawbacks:** Configuration option was only added for Sphinx 1.7+

**Related GitHub Issues:** n/a
