### PR TITLE
Fix a bug where gallery card margins would not reduce on smaller width displays

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,18 +6,12 @@
 
 ### Bug fixes
 
-* Fixes a bug where the navbar would incorrectly display a drop shadow
+* Fixed a bug where the navbar would incorrectly display a drop shadow
   with small screen widths when the global TOC was active.
   [#20](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/20)
 
-* Fixes a bug where gallery card margins would not reduce on smaller
+* Fixed a bug where gallery card margins would not reduce on smaller
   width displays. [#22](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/22)
-
-### Bug fixes
-
-* Fixes a bug where the navbar would incorrectly display a drop shadow
-  with small screen widths when the global TOC was active.
-  [#20](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/20)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 ### Bug fixes
 
-- Fixes a bug where the navbar would incorrectly display a drop shadow
+* Fixes a bug where the navbar would incorrectly display a drop shadow
   with small screen widths when the global TOC was active.
   [#20](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/20)
+
+* Fixes a bug where gallery card margins would not reduce on smaller
+  width displays. [#22](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/22)
 
 ### Bug fixes
 

--- a/doc/gallery.rst
+++ b/doc/gallery.rst
@@ -12,6 +12,11 @@ Example showing usage of Sphinx Gallery.
     :description: :doc:`gallery/tutorial_demo`
     :figure: _static/teleport.png
 
+
+.. gallery-item::
+    :description: :doc:`directives`
+    :figure: _static/xst_title.svg
+
 .. raw:: html
 
     </div><div style='clear:both'>

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2720,12 +2720,14 @@ pre {
   margin: 0 0 .1em 0;
 }
 
-.gallery-item-thumbcontainer > div.figure {
+.gallery-item-thumbcontainer > div.figure,
+.gallery-item-thumbcontainer > figure {
   padding-bottom: 10px;
   padding-top: 10px;
 }
 
-.gallery-item-thumbcontainer .figure {
+.gallery-item-thumbcontainer .figure,
+.gallery-item-thumbcontainer figure {
   margin: 10px;
   width: 160px;
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -1757,6 +1757,7 @@ footer.page-footer .footer-copyright {
 @media screen and (max-width: 560px) {
   .gallery-item-thumbcontainer {
     width: calc(100% / 2.2);
+    margin: 5px !important;
   }
 
   .gallery-item-thumbcontainer img {


### PR DESCRIPTION
**Context:** On smaller width displays, gallery cards would display as single column with large margins.

**Description of the Change:** Reduces the gallery card margins on small displays, to allow two column displays.

**Benefits:** As above.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
