### PR TITLE
Fix squished author bio photos

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,14 @@
-## Release 0.4.0 (development release)
+## Release 0.3.2
+
+### Bug fixes
+
+* Fixed a bug where author bio photos would appear squished. [#25](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/25)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Josh Izaac](https://github.com/josh146).
 
 ## Release 0.3.1 (current release)
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3069,8 +3069,10 @@ p.sphx-glr-signature a.reference.external {
     margin-right: 1em;
 }
 .photo__img {
-    width: 100%;
+    width: 60px;
     border-radius: 50%;
+    height: 60px;
+    object-fit: cover;
 }
 .bio-text__author-name {
     margin-top: 0;


### PR DESCRIPTION
**Context:** In https://github.com/PennyLaneAI/qml/pull/564, @LucasSilbernagel fixed the author bio photos becoming 'squished'. However, this change was accidentally not carried over to the XST.

**Description of the Change:** Duplicates this functionality in the XST.

**Benefits:** Author bio photos will no longer be squished.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
