### PR TITLE
Fixed an issue where footnote references were being rendered without brackets

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,15 @@
-## Release 0.4.0 (development release)
+## Release 0.3.3 (current release)
+
+### Bug fixes
+
+* Fixed an issue where footnote references were being rendered without brackets.
+  [#25](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/25)
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Josh Izaac](https://github.com/josh146).
 
 ## Release 0.3.2
 

--- a/doc/tutorials/tutorial_demo.py
+++ b/doc/tutorials/tutorial_demo.py
@@ -2,7 +2,8 @@
 Example Sphinx-Gallery demo
 ===========================
 
-This tutorial is an example demo generated using Sphinx Gallery.
+This tutorial is an example demo generated using Sphinx Gallery. Here are a few
+references to see what they look like [#stokes2019]_ [#sweke2019]_.
 
 System Info
 -----------
@@ -23,6 +24,20 @@ print(f"Machine: {uname.machine}")
 print(f"Processor: {uname.processor}")
 
 ###############################################################
+# References
+# ----------
+#
+# .. [#stokes2019]
+#
+#     James Stokes, Josh Izaac, Nathan Killoran, and Giuseppe Carleo. "Quantum Natural Gradient."
+#     `arXiv:1909.02108 <https://arxiv.org/abs/1909.02108>`__ (2019).
+#
+# .. [#sweke2019]
+#
+#     Ryan Sweke, Frederik Wilde, Johannes Jakob Meyer, Maria Schuld, Paul K. Fährmann, Barthélémy
+#     Meynard-Piganeau, and Jens Eisert. "Stochastic gradient descent for hybrid quantum-classical
+#     optimization." `arXiv:1910.01155 <https://arxiv.org/abs/1910.01155>`__ (2019).
+#
 # Author
 # ------
 #

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -1442,6 +1442,14 @@ dl.glossary dt {
   background-color: #ffa;
 }
 
+.footnote-reference.brackets::before {
+  content: "[";
+}
+
+.footnote-reference.brackets::after {
+  content: "]";
+}
+
 .line-block {
   display: block;
   margin-top: 1em;


### PR DESCRIPTION
**Context:** This was previously fixed in the QML repo, but the fix must have been accidentally reverted when porting to the Xanadu Sphinx Theme.

**Description of the Change:** As title.

**Benefits:** As title.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
