### PR TITLE
Fix issue where twitter cards not registering

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,18 @@
-## Release 0.3.3 (current release)
+## Release 0.3.4 (current release)
+
+### Bug fixes
+
+* Fixed an issue the `meta` directive in ReST files was not properly registering
+  an open graph Twitter card.
+  [#27](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/27)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Josh Izaac](https://github.com/josh146).
+
+## Release 0.3.3
 
 ### Bug fixes
 

--- a/doc/tutorials/tutorial_demo.py
+++ b/doc/tutorials/tutorial_demo.py
@@ -2,6 +2,10 @@
 Example Sphinx-Gallery demo
 ===========================
 
+.. meta::
+    :property="og:description": An example demo using the Xanadu Sphinx Theme generated using Sphinx Gallery.
+    :property="og:image": https://pennylane.ai/qml/_static/wigner.png
+
 This tutorial is an example demo generated using Sphinx Gallery. Here are a few
 references to see what they look like [#stokes2019]_ [#sweke2019]_.
 

--- a/xanadu_sphinx_theme/_version.py
+++ b/xanadu_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the Xanadu Sphinx Theme version with https://semver.org/
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -2,6 +2,17 @@
 
 {# Do this so that bootstrap is included before the main CSS file. #}
 {%- block htmltitle %}
+
+
+  <meta property="og:title" content="{{ title|striptags|e }} &#8212; PennyLane">
+  <meta property="og:url" content="{{ pageurl }}">
+  <meta name="twitter:card" content="summary_large_image">
+
+  {% if metatags is defined %}
+  {% set description = metatags.split('\n') %}
+  {{ description[0] | replace("og:", "") | replace("property", "name") }}
+  {% endif %}
+
   <!-- Google Fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto&display=swap">


### PR DESCRIPTION
**Context:** The `.. meta::` directive in ReST is supposed to automatically create HTML `<meta>` tags, and we use this in the QML repo to automatically register [Open Graph](https://ogp.me/) social media cards. However, this was not working.

**Description of the Change:** Add Jinja2 templating to ensure the OpenGraph card is correctly created.

**Benefits:** Fixes bug, card will now display on Twitter.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
