### PR TITLE
Enable custom href fragment for details directive

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,11 +5,15 @@
 * Fixed an issue where footnote references were being rendered without brackets.
   [#25](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/25)
 
+* Added the option to customize the href fragment of the details directive
+  [#26](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/26)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
 [Josh Izaac](https://github.com/josh146).
+[David Wierichs](https://github.com/dwierichs).
 
 ## Release 0.3.2
 

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -38,8 +38,8 @@ Details Dropdown
 .. code-block:: rest
 
     .. details::
-        :title: Important Usage Details
-        :href: #usage-details
+        :title: Important Details
+        :href: #important-details
 
         In general, the block takes D parameters and **must** have the following signature:
 
@@ -49,12 +49,23 @@ Details Dropdown
 
         For a block with multiple parameters, ``n_params_block`` is equal to the number of parameters in ``block``.
         For a block with a single parameter, ``n_params_block`` is equal to the length of the parameter array.
+
+    .. details::
+        :title: Usage Details
+
+        This function can be used with any of the supported autodifferentiation frameworks. It also supports
+        just-in-time compilation with JAX:
+
+        .. code-block:: python
+
+            jax.jit(unitary)(parameter1, parameter2, ... parameterD, wires)
+
 
 .. admonition:: Example:
 
     .. details::
-        :title: Important Usage Details
-        :href: #usage-details
+        :title: Important Details
+        :href: #important-details
 
         In general, the block takes D parameters and **must** have the following signature:
 
@@ -64,6 +75,16 @@ Details Dropdown
 
         For a block with multiple parameters, ``n_params_block`` is equal to the number of parameters in ``block``.
         For a block with a single parameter, ``n_params_block`` is equal to the length of the parameter array.
+
+    .. details::
+        :title: Usage Details
+
+        This function can be used with any of the supported autodifferentiation frameworks. It also supports
+        just-in-time compilation with JAX:
+
+        .. code-block:: python
+
+            jax.jit(unitary)(parameter1, parameter2, ... parameterD, wires)
 
 
 Gallery Item

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -39,6 +39,7 @@ Details Dropdown
 
     .. details::
         :title: Usage Details
+        :href: #usage-details
 
         In general, the block takes D parameters and **must** have the following signature:
 

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -38,7 +38,7 @@ Details Dropdown
 .. code-block:: rest
 
     .. details::
-        :title: Usage Details
+        :title: Important Usage Details
         :href: #usage-details
 
         In general, the block takes D parameters and **must** have the following signature:
@@ -53,7 +53,8 @@ Details Dropdown
 .. admonition:: Example:
 
     .. details::
-        :title: Usage Details
+        :title: Important Usage Details
+        :href: #usage-details
 
         In general, the block takes D parameters and **must** have the following signature:
 

--- a/xanadu_sphinx_theme/directives/details.py
+++ b/xanadu_sphinx_theme/directives/details.py
@@ -31,8 +31,9 @@ TEMPLATE = cleandoc(
 )
 
 
-def lower_and_hyphenize(s):
-    return s.lower().replace(" ", "-")
+def lower_and_hyphenize(string):
+    """Turns a string into lower case and replaces spaces by hyphens."""
+    return string.lower().replace(" ", "-")
 
 
 class DetailsDirective(Directive):

--- a/xanadu_sphinx_theme/directives/details.py
+++ b/xanadu_sphinx_theme/directives/details.py
@@ -12,7 +12,7 @@ TEMPLATE = cleandoc(
         <a
           class="details-header collapse-header"
           data-toggle="collapse"
-          href="#details"
+          href="{title_fragment}"
           aria-expanded="false"
           aria-controls="details"
         >
@@ -43,7 +43,10 @@ class DetailsDirective(Directive):
 
     def run(self):
         title = self.options.get("title", "Details and Conventions")
-        rst = TEMPLATE.format(title=title, content="\n".join(self.content))
+        title_fragment = self.options.get("href", title.replace(" ", "-"))
+        rst = TEMPLATE.format(
+            title=title, content="\n".join(self.content), title_fragment=title_fragment
+        )
         string_list = StringList(rst.split("\n"))
         node = nodes.tbody()
         self.state.nested_parse(string_list, self.content_offset, node)

--- a/xanadu_sphinx_theme/directives/details.py
+++ b/xanadu_sphinx_theme/directives/details.py
@@ -42,7 +42,7 @@ class DetailsDirective(Directive):
     add_index = False
 
     def run(self):
-        title = self.options.get("title", "Details and Conventions")
+        title = self.options.get("title", "Usage Details")
         title_fragment = self.options.get("href", title.replace(" ", "-"))
         rst = TEMPLATE.format(
             title=title, content="\n".join(self.content), title_fragment=title_fragment

--- a/xanadu_sphinx_theme/directives/details.py
+++ b/xanadu_sphinx_theme/directives/details.py
@@ -12,7 +12,7 @@ TEMPLATE = cleandoc(
         <a
           class="details-header collapse-header"
           data-toggle="collapse"
-          href="{title_fragment}"
+          href="#{href}"
           aria-expanded="false"
           aria-controls="details"
         >
@@ -20,7 +20,7 @@ TEMPLATE = cleandoc(
                 <i class="fas fa-angle-down rotate" style="float: right;"></i> {title}
             </h2>
         </a>
-        <div class="collapse" id="details">
+        <div class="collapse" id="{href}">
 
     {content}
 
@@ -31,22 +31,23 @@ TEMPLATE = cleandoc(
 )
 
 
+def lower_and_hyphenize(s):
+    return s.lower().replace(" ", "-")
+
 class DetailsDirective(Directive):
     """Creates a collapsable Details section."""
 
     required_arguments = 0
     optional_arguments = 0
     final_argument_whitespace = False
-    option_spec = {"title": directives.unchanged}
+    option_spec = {"title": directives.unchanged, "href": lower_and_hyphenize}
     has_content = True
     add_index = False
 
     def run(self):
         title = self.options.get("title", "Usage Details")
-        title_fragment = self.options.get("href", title.replace(" ", "-"))
-        rst = TEMPLATE.format(
-            title=title, content="\n".join(self.content), title_fragment=title_fragment
-        )
+        href = self.options.get("href", lower_and_hyphenize(title))
+        rst = TEMPLATE.format(title=title, content="\n".join(self.content), href=href)
         string_list = StringList(rst.split("\n"))
         node = nodes.tbody()
         self.state.nested_parse(string_list, self.content_offset, node)

--- a/xanadu_sphinx_theme/directives/details.py
+++ b/xanadu_sphinx_theme/directives/details.py
@@ -34,6 +34,7 @@ TEMPLATE = cleandoc(
 def lower_and_hyphenize(s):
     return s.lower().replace(" ", "-")
 
+
 class DetailsDirective(Directive):
     """Creates a collapsable Details section."""
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new classes, functions, and members must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format lint`.

- [x] Add a new entry to [`CHANGELOG.md`](.github/CHANGELOG.md), summarizing the
      change and including a link back to the PR.

- [x] If applicable, include a screenshot or GIF to illustrate visual changes.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
The `.. details::` directive adds a drop-down section to documentation entries.
These sections automatically have the URL fragment `#details`.

**Description of the Change:**
This PR automatically derives the fragment from the `title` given to the `details` section, and allows to pass a custom fragment via the `href` option instead:
```rest
.. details::
    :title: Very interesting details on JAX
    :href: details-jax
```

In addition, this PR changes the default for the `title` option from "Details and Conventions" to "Usage Details".

**Benefits:**
More descriptive URLs.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A
