### PR TITLE
Bump pillow version to mitigate Data Amplification attack

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
 ## Release 0.3.4 (current release)
 
 ### Bug fixes

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 m2r2
 matplotlib==3.5.3
-pillow==9.1.1
+pillow==9.3.0
 sphinx==4.5.0
 sphinx-copybutton
 sphinx-gallery==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 importlib-resources==5.9.0
-pillow==9.1.1
+pillow==9.3.0
 sphinx==4.5.0
 sphinx-gallery==0.10.1


### PR DESCRIPTION
**Context:**

There is a security vulnerability (Data Amplification attack) in Pillow prior to v9.2.0.

**Description of the Change:**

* Bumped the version of Pillow from 9.1.1 to 9.3.0.

**Benefits:**

* Local development of the Xanadu Sphinx Theme is marginally more secure.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.
