### PR TITLE
Set `dropdown_link` to `[]` by default

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * Bumped `wheel` to v0.38.1. [(#33](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/33)
 
+### Bug fixes
+
+* Fixed an issue where the `dropdown_link` Jinja variable is accessed but undefined.
+  [#36](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/36)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/xanadu_sphinx_theme/_version.py
+++ b/xanadu_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the Xanadu Sphinx Theme version with https://semver.org/
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.3.6"
+__version__ = "0.4.0-dev"

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -43,6 +43,8 @@
 {% if use_hover_toc and theme_navbar_left_links|length != 0 %}
   {# Extract active navbar entries #}
   {% set dropdown_link = theme_navbar_left_links|selectattr("active") | map(attribute="name") | list %}
+{% else %}
+  {% set dropdown_link = [] %}
 {% endif %}
 
 {% if use_hover_toc and dropdown_link|length == 0 %}


### PR DESCRIPTION
**Context:**

Presently, if the hover ToC  option is specified, at least one left navbar link _must_ be specified. If no links are specified, Sphinx fails to build the documentation with an error such as:

```
Theme error:
An error happened in rendering the page api/xanadu_sphinx_theme.
Reason: UndefinedError("'dropdown_link' is undefined")
```

**Description of the Change:**

* Defined the `dropdown_link` Jinja variable to be the empty list if no left navbar links are specified.

**Benefits:**

* The Xanadu Sphinx Theme is fully compatible with projects that require `Jinja2 == 3.0.0`.

**Possible Drawbacks:**

* None

**Related GitHub Issues:**

* Resolves #35.