### PR TITLE
Bump Pillow to version 10.0.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Added missing Read the Docs configuration file.
   [(#42)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/42)
 
+* Bumped `pillow` to version 10.0.1. [(#43)](https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/43)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 m2r2
 matplotlib==3.5.3
-pillow==9.3.0
+pillow==10.0.1
 sphinx==4.5.0
 sphinx-copybutton
 sphinx-gallery==0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 importlib-resources==5.9.0
-pillow==9.3.0
+pillow==10.0.1
 sphinx==4.5.0
 sphinx-gallery==0.10.1


### PR DESCRIPTION
**Context:**

Dependabot identified a pair of security vulnerabilities in Pillow that were patched in v10.0.1.

**Description of the Change:**

* Bumped the pinned `pillow` version to 10.0.1.
* Bumped the Python version used by GitHub Actions (to use the latest version of Pillow).

**Benefits:**

* This project no longer has any known security vulnerabilities. 🎉 

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.