### PR TITLE
Improve accessibility of navbar and footer

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Release 0.5.0 (development release)
+## Release 0.5.0 (current release)
 
 ### Improvements
 
@@ -23,7 +23,7 @@ This release contains contributions from (in alphabetical order):
 
 [Mikhail Andrenkov](https://github.com/Mandrenkov).
 
-## Release 0.4.0 (current release)
+## Release 0.4.0
 
 ### Improvements
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Release 0.5.0 (development release)
 
+### Improvements
+
+* Improved the accessibility of the navbar and footer by adding missing `alt`
+  text and ARIA labels and fixing issues with keyboard navigation.
+  [(#43)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/43)
+
 ### Bug fixes
 
 * Obviated the need for horizontal scrolling on mobile.

--- a/README.rst
+++ b/README.rst
@@ -256,17 +256,19 @@ The following options customize the appearance of the footer.
 
         "footer_social_icons": [
             {
+                "name": "Twitter",
                 "icon": "fab fa-twitter",
                 "href": "https://twitter.com/xanaduai"
             },
             {
+                "name": "GitHub",
                 "icon": "fab fa-github",
                 "href": "https://github.com/XanaduAI"
             },
             ...
         ]
 
-    specifying social media icons. ``icon`` should correspond to a FontAwesome5 icon.
+    specifying social media icons. ``icon`` should correspond to a Boxicons icon.
     Set to an empty list to remove.
 
 ``footer_taglines``

--- a/README.rst
+++ b/README.rst
@@ -136,9 +136,11 @@ The following options customize the appearance of the navigation bar.
 
 ``navbar_wordmark_path``
     Path to the project wordmark to appear in the navigation bar. Specifying
-    this option will replace the project name in the navigation bar. Eventually,
-    this option will be removed in favour of ``navbar_name`` for the sake of
-    consistency.
+    this option will replace the project logo and name in the navigation bar.
+
+``navbar_logo_alt``
+    Alternative text to display in lieu of the wordmark or logo in the navigation bar.
+    Defaults to the value of ``navbar_name``.
 
 ``navbar_logo_path``
     Path to the project logo that appears in the navigation bar. Defaults to

--- a/xanadu_sphinx_theme/__init__.py
+++ b/xanadu_sphinx_theme/__init__.py
@@ -162,26 +162,32 @@ XANADU_FOOTER = {
     ],
     "footer_social_icons": [
         {
+            "name": "Twitter",
             "icon": "bx bxl-twitter",
             "href": "https://twitter.com/xanaduai",
         },
         {
+            "name": "GitHub",
             "icon": "bx bxl-github",
             "href": "https://github.com/XanaduAI",
         },
         {
+            "name": "LinkedIn",
             "icon": "bx bxl-linkedin",
             "href": "https://linkedin.com/company/xanaduai/",
         },
         {
+            "name": "Discourse",
             "icon": "bx bxl-discourse",
             "href": "https://discuss.pennylane.ai",
         },
         {
+            "name": "Slack",
             "icon": "bx bxl-slack",
             "href": "https://u.strawberryfields.ai/slack",
         },
         {
+            "name": "RSS",
             "icon": "bx bx-rss",
             "href": "https://xanadu.ai/blog",
         },

--- a/xanadu_sphinx_theme/_version.py
+++ b/xanadu_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the Xanadu Sphinx Theme version with https://semver.org/
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.5.0-dev"
+__version__ = "0.5.0"

--- a/xanadu_sphinx_theme/footer.html
+++ b/xanadu_sphinx_theme/footer.html
@@ -16,7 +16,7 @@
       <!-- Social Icons -->
       <div class="footer-social-icons">
         {% for link in theme_footer_social_icons %}
-          <a href="{{ link.href }}">
+          <a href="{{ link.href }}" aria-label="{{ link.name }}">
             <i class="{{ link.icon }}"></i>
           </a>
         {% endfor %}

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -1,11 +1,12 @@
 <nav>
   <!-- Logo and Title -->
 
-  <a class="navbar-logo-title-container" href="{{ pathto(theme_navbar_home_link, 1) }}">
+  <a class="navbar-logo-title-container" href="{{ pathto(theme_navbar_home_link, 1) }}" aria-label="home">
+    {% set navbar_alt = theme_navbar_logo_alt if theme_navbar_logo_alt else theme_navbar_name %}
     {% if theme_navbar_wordmark_path %}
-      <img class="navbar-logo-title-image" src="{{ pathto(theme_navbar_wordmark_path, 1) }}" height="24px"></img>
+      <img class="navbar-logo-title-image" src="{{ pathto(theme_navbar_wordmark_path, 1) }}" alt="{{ navbar_alt }}" height="24px"></img>
     {% else %}
-      <img class="navbar-logo-title-logo" src=" {{ pathto(theme_navbar_logo_path, 1) }}" height="24px"></img>
+      <img class="navbar-logo-title-logo" src=" {{ pathto(theme_navbar_logo_path, 1) }}" alt="{{ navbar_alt }}" height="24px"></img>
       <div class="navbar-logo-title-title">{{ theme_navbar_name }}</div>
     {% endif %}
   </a>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -156,7 +156,7 @@
   {% endmacro %}
 
   <div class="navbar-menu mobile">
-    <button onclick="toggleMobileNavbar(this)">
+    <button onclick="toggleMobileNavbar(this)" aria-label="open menu" aria-expanded="false">
       <i class="bx bx-menu"></i>
       <i class="bx bx-x"></i>
     </button>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -16,19 +16,19 @@
   {% macro render_desktop_navbar_left_link(name, href=None, img=None, width=None, external=false, dropdown=[]) %}
     <li class="navbar-left-link desktop">
       {% if img %}
-        <a href="{{ pathto(href, 1) }}">
+        <a href="{{ pathto(href, 1) }}" aria-label="{{ name }}">
           <img src="{{ pathto(img, 1) }}" height="35px" {% if width %} width="{{ width }}" {% endif %} />
           <span>{{ name }}</span>
         </a>
       {% else %}
-        <a href="{{ pathto(href, 1) }}" {% if external %} target="_blank" {% endif %}>
+        <a href="{{ pathto(href, 1) }}" aria-label="{{ name }}" {% if external %} target="_blank" {% endif %}>
           <span>{{ name }}</span>
           {% if external %}
             <i class="bx bx-link-external"></i>
           {% endif %}
         </a>
         {% if dropdown %}
-          <button>
+          <button aria-label="open {{ name }} sub-menu" aria-expanded="false">
             <i class="bx bx-chevron-down"></i>
           </button>
           <ul class="navbar-dropdown desktop">
@@ -97,7 +97,7 @@
   {% macro render_mobile_navbar_link(name, href, external=false, dropdown=[]) %}
     <li class="navbar-link mobile">
       {% if dropdown %}
-        <button class="navbar-link-heading mobile" onclick="toggleMobileNavbarLink(this)">
+        <button class="navbar-link-heading mobile" onclick="toggleMobileNavbarLink(this)" aria-label="open {{ name }} sub-menu" aria-expanded="false">
           <div>
             <span>{{ name }}</span>
             {% if external %}

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -16,12 +16,12 @@
   {% macro render_desktop_navbar_left_link(name, href=None, img=None, width=None, external=false, dropdown=[]) %}
     <li class="navbar-left-link desktop">
       {% if img %}
-        <a href="{{ pathto(href, 1) }}" aria-label="{{ name }}">
+        <a href="{{ pathto(href, 1) }}">
           <img src="{{ pathto(img, 1) }}" height="35px" {% if width %} width="{{ width }}" {% endif %} />
           <span>{{ name }}</span>
         </a>
       {% else %}
-        <a href="{{ pathto(href, 1) }}" aria-label="{{ name }}" {% if external %} target="_blank" {% endif %}>
+        <a href="{{ pathto(href, 1) }}" {% if external %} target="_blank" {% endif %}>
           <span>{{ name }}</span>
           {% if external %}
             <i class="bx bx-link-external"></i>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -53,7 +53,7 @@
   {% macro render_desktop_navbar_right_link(name, href, icon=None) %}
     <li class="navbar-right-link desktop">
       {% if icon %}
-        <a href="{{ pathto(href, 1) }}" target="_blank">
+        <a href="{{ pathto(href, 1) }}" target="_blank" aria-label="{{ name }}">
           <i class="{{ icon }}"></i>
         </a>
       {% else %}

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -423,6 +423,7 @@
   <!-- Utility functions for setting ARIA attributes on buttons that show menus. -->
   <script type="text/javascript">
     function setAriaAttributes(button, expand) {
+      console.log("setAriaAttributes()", button, expand);
       const skip = button.ariaLabel.indexOf(" ");
       const menu = button.ariaLabel.substr(skip);
       button.ariaLabel = (expand ? "close" : "open") + menu;
@@ -444,10 +445,12 @@
         const button = link.querySelector("button");
         if (dropdown !== null) {
           timers[i] = {link: link, button: button, timeout: undefined};
+          console.log("for", i, timers[i]);
 
           // Expands the current dropdown and closes other dropdowns.
           const expandDropdown = () => {
             for (const [j, timer] of Object.entries(timers)) {
+              console.log("expandDropdown()", i, j, timer);
               clearTimeout(timer.timeout);
               if (i !== j) {
                 timer.link.classList.remove("open");
@@ -461,6 +464,7 @@
           // Closes the current dropdown after the given delay.
           const collapseDropdown = (event, delay = 1000) => {
             timers[i].timeout = setTimeout(function(event){
+              console.log("collapseDropdown()", i, link, button, timers[i].timeout);
               link.classList.remove("open");
               setAriaAttributes(button, false);
             }, delay);

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -561,43 +561,32 @@
   <script type="text/javascript">
     // Using ``keyup`` would cause the last element to be quickly "skipped".
     $(document).keydown(function(event) {
-      // Do nothing if the navbar dropdown is collapsed on mobile.
-      const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
-      if (mobileMenuButton === null || !mobileMenuButton.classList.contains("open")) {
-        return;
-      }
+      // The keycode of TAB is 9.
+      if (event.keyCode == 9) {
+        // Do nothing if the navbar dropdown is collapsed on mobile.
+        const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
+        if (mobileMenuButton === null || !mobileMenuButton.classList.contains("open")) {
+          return;
+        }
 
-      const links = document.querySelectorAll(".mobile.navbar-links a");
-      const bot = links[links.length - 1];
-      const top = document.querySelector(".mobile.navbar-menu button");
+        const links = document.querySelectorAll(".mobile.navbar-links a");
+        const bot = links[links.length - 1];
+        const top = document.querySelector(".mobile.navbar-menu button");
 
-      // Do nothing if there is a missing focus element.
-      if (top === null || bot === undefined) {
-        return;
-      }
+        // Do nothing if there is a missing focus element.
+        if (top === null || bot === undefined) {
+          return;
+        }
 
-      const forward = (
-        // TAB
-        (!event.shiftKey && event.keyCode == 9) ||
-        // OPTION + COMMAND + RIGHT
-        (event.metaKey && event.altKey && event.keyCode == 39)
-      );
-
-      const backward = (
-        // SHIFT + TAB
-        (event.shiftKey && event.keyCode == 9) ||
-        // OPTION + COMMAND + LEFT
-        (event.metaKey && event.altKey && event.keyCode == 37)
-      );
-
-      // Wrap the focus to the top or bottom element if needed. The direction
-      // of the wrapping depends on the direction of navigation.
-      if (forward && document.activeElement === bot) {
-        top.focus();
-        event.preventDefault();
-      } else if (backward && document.activeElement === top) {
-        bot.focus();
-        event.preventDefault();
+        // Wrap the focus to the top or bottom element if needed. The direction
+        // of the wrapping depends on whether TAB or SHIFT + TAB is pressed.
+        if (!event.shiftKey && document.activeElement === bot) {
+          top.focus();
+          event.preventDefault();
+        } else if (event.shiftKey && document.activeElement === top) {
+          bot.focus();
+          event.preventDefault();
+        }
       }
     });
   </script>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -510,6 +510,12 @@
         dropdown.classList.toggle("open");
         button.classList.toggle("open");
         toggleAriaAttributes(button);
+
+        const hidden = button.getAttribute("aria-expanded") === "true";
+        const hidden_elements = document.querySelectorAll(".container-wrapper, footer");
+        for (const element of hidden_elements) {
+          element.setAttribute("aria-hidden", hidden.toString());
+        }
       }
     }
   </script>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -556,6 +556,40 @@
     });
   </script>
 
+  <!-- Trap focus in the navbar dropdown on mobile if it is expanded. -->
+  <script type="text/javascript">
+    // Using ``keyup`` would cause the last element to be quickly "skipped".
+    $(document).keydown(function(event) {
+      // The keycode of TAB is 9.
+      if (event.keyCode == 9) {
+        // Do nothing if the navbar dropdown is collapsed on mobile.
+        const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
+        if (mobileMenuButton === null || !mobileMenuButton.classList.contains("open")) {
+          return;
+        }
+
+        const links = document.querySelectorAll(".mobile.navbar-links a");
+        const bot = links[links.length - 1];
+        const top = document.querySelector(".mobile.navbar-menu button");
+
+        // Do nothing if there is a missing focus element.
+        if (top === null || bot === undefined) {
+          return;
+        }
+
+        // Wrap the focus to the top or bottom element if needed. The direction
+        // of the wrapping depends on whether TAB or SHIFT + TAB is pressed.
+        if (!event.shiftKey && document.activeElement === bot) {
+          top.focus();
+          event.preventDefault();
+        } else if (event.shiftKey && document.activeElement === top) {
+          bot.focus();
+          event.preventDefault();
+        }
+      }
+    });
+  </script>
+
   <script type="text/javascript">
     jQuery.noConflict(true);
   </script>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -468,7 +468,13 @@
       const dropdown = document.querySelector(".mobile.navbar-links");
       if (dropdown !== null) {
         dropdown.classList.toggle("open");
-        button.classList.toggle("open");
+        if (button.classList.toggle("open")) {
+          button.ariaLabel = "close menu";
+          button.ariaExpanded = "true";
+        } else {
+          button.ariaLabel = "open menu";
+          button.ariaExpanded = "false";
+        }
       }
     }
   </script>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -420,6 +420,20 @@
     });
   </script>
 
+  <!-- Utility functions for setting ARIA attributes on buttons that show menus. -->
+  <script type="text/javascript">
+    function setAriaAttributes(button, expand) {
+      const skip = button.ariaLabel.indexOf(" ");
+      const menu = button.ariaLabel.substr(skip);
+      button.ariaLabel = (expand ? "close" : "open") + menu;
+      button.ariaExpanded = expand.toString();
+    }
+
+    function toggleAriaAttributes(button) {
+      setAriaAttributes(button, button.ariaExpanded === "false");
+    }
+  </script>
+
   <!-- Delays the closing of dropdowns on the LHS of the navigation bar. -->
   <script type="text/javascript">
     $(document).ready(() => {
@@ -427,22 +441,26 @@
       const navbar_left_links = document.querySelectorAll(".navbar-left-link");
       for (const [i, link] of navbar_left_links.entries()) {
         const dropdown = link.querySelector(".navbar-dropdown");
+        const button = link.querySelector("button");
         if (dropdown !== null) {
-          timers[i] = {link: link, timeout: undefined};
+          timers[i] = {link: link, button: button, timeout: undefined};
 
           link.addEventListener("mouseenter", function(event){
             for (const [j, timer] of Object.entries(timers)) {
               clearTimeout(timer.timeout);
               if (i !== j) {
                 timer.link.classList.remove("open")
+                setAriaAttributes(timer.button, false);
               }
             }
             link.classList.add("open");
+            setAriaAttributes(button, true);
           });
 
           link.addEventListener("mouseleave", function(event){
             timers[i].timeout = setTimeout(function(event){
               link.classList.remove("open");
+              setAriaAttributes(button, false);
             }, 1000);
           });
         }
@@ -468,13 +486,8 @@
       const dropdown = document.querySelector(".mobile.navbar-links");
       if (dropdown !== null) {
         dropdown.classList.toggle("open");
-        if (button.classList.toggle("open")) {
-          button.ariaLabel = "close menu";
-          button.ariaExpanded = "true";
-        } else {
-          button.ariaLabel = "open menu";
-          button.ariaExpanded = "false";
-        }
+        button.classList.toggle("open");
+        toggleAriaAttributes(button);
       }
     }
   </script>
@@ -482,7 +495,8 @@
   <!-- Toggles whether the dropdown from a navbar link is displayed on mobile. -->
   <script type="text/javascript">
     function toggleMobileNavbarLink(button) {
-      const link = button.parentElement.classList.toggle("open");
+      button.parentElement.classList.toggle("open");
+      toggleAriaAttributes(button);
     }
   </script>
 

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -478,13 +478,6 @@
           link.addEventListener("mouseenter", expandDropdown);
           link.addEventListener("mouseleave", collapseDropdown);
           button.addEventListener("click", toggleDropdown);
-
-          button.addEventListener("keyup", function(event){
-            // The keycode of ESC is 13.
-            if (event.keyCode === 13) {
-              toggleDropdown()
-            }
-          })
         }
       }
     });

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -469,7 +469,7 @@
           // Toggles the current dropdown.
           const toggleDropdown = (event) => {
             if (link.classList.contains("open")) {
-              collapseDropdown(0);
+              collapseDropdown(event, 0);
             } else {
               expandDropdown();
             }
@@ -477,6 +477,7 @@
 
           link.addEventListener("mouseenter", expandDropdown);
           link.addEventListener("mouseleave", collapseDropdown);
+          button.addEventListener("click", toggleDropdown);
 
           button.addEventListener("keyup", function(event){
             // The keycode of ESC is 13.

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -459,7 +459,7 @@
           }
 
           // Closes the current dropdown after the given delay.
-          const collapseDropdown = (delay = 1000) => {
+          const collapseDropdown = (event, delay = 1000) => {
             timers[i].timeout = setTimeout(function(event){
               link.classList.remove("open");
               setAriaAttributes(button, false);
@@ -467,7 +467,7 @@
           }
 
           // Toggles the current dropdown.
-          const toggleDropdown = () => {
+          const toggleDropdown = (event) => {
             if (link.classList.contains("open")) {
               collapseDropdown(0);
             } else {

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -445,24 +445,45 @@
         if (dropdown !== null) {
           timers[i] = {link: link, button: button, timeout: undefined};
 
-          link.addEventListener("mouseenter", function(event){
+          // Expands the current dropdown and closes other dropdowns.
+          const expandDropdown = () => {
             for (const [j, timer] of Object.entries(timers)) {
               clearTimeout(timer.timeout);
               if (i !== j) {
-                timer.link.classList.remove("open")
+                timer.link.classList.remove("open");
                 setAriaAttributes(timer.button, false);
               }
             }
             link.classList.add("open");
             setAriaAttributes(button, true);
-          });
+          }
 
-          link.addEventListener("mouseleave", function(event){
+          // Closes the current dropdown after the given delay.
+          const collapseDropdown = (delay = 1000) => {
             timers[i].timeout = setTimeout(function(event){
               link.classList.remove("open");
               setAriaAttributes(button, false);
-            }, 1000);
-          });
+            }, delay);
+          }
+
+          // Toggles the current dropdown.
+          const toggleDropdown = () => {
+            if (link.classList.contains("open")) {
+              collapseDropdown(0);
+            } else {
+              expandDropdown();
+            }
+          }
+
+          link.addEventListener("mouseenter", expandDropdown);
+          link.addEventListener("mouseleave", collapseDropdown);
+
+          button.addEventListener("keyup", function(event){
+            // The keycode of ESC is 13.
+            if (event.keyCode === 13) {
+              toggleDropdown()
+            }
+          })
         }
       }
     });
@@ -498,6 +519,41 @@
       button.parentElement.classList.toggle("open");
       toggleAriaAttributes(button);
     }
+  </script>
+
+  <!-- Collapses the most specific menu when ESC is pressed. -->
+  <script type="text/javascript">
+    $(document).keyup(function(event) {
+      // The keycode of ESC is 27.
+      if (event.keyCode == 27) {
+        // Collapse an open dropdown from a navbar link on mobile.
+        const mobileSubMenuButtons = document.querySelectorAll(".mobile.navbar-link button");
+        for (const button of mobileSubMenuButtons) {
+          if (button.parentElement.classList.contains("open")) {
+            toggleMobileNavbarLink(button);
+            return;
+          }
+        }
+
+        // Collapse the navbar dropdown on mobile.
+        const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
+        if (mobileMenuButton !== null && mobileMenuButton.classList.contains("open")) {
+          toggleMobileNavbar(mobileMenuButton);
+          return;
+        }
+
+        // Close an open navbar dropdown on desktop.
+        const navbar_left_links = document.querySelectorAll(".navbar-left-link");
+        for (const link of navbar_left_links.values()) {
+          const button = link.querySelector("button");
+          if (link.classList.contains("open")) {
+            link.classList.remove("open");
+            setAriaAttributes(button, true);
+            return;
+          }
+        }
+      }
+    });
   </script>
 
   <script type="text/javascript">

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -561,32 +561,43 @@
   <script type="text/javascript">
     // Using ``keyup`` would cause the last element to be quickly "skipped".
     $(document).keydown(function(event) {
-      // The keycode of TAB is 9.
-      if (event.keyCode == 9) {
-        // Do nothing if the navbar dropdown is collapsed on mobile.
-        const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
-        if (mobileMenuButton === null || !mobileMenuButton.classList.contains("open")) {
-          return;
-        }
+      // Do nothing if the navbar dropdown is collapsed on mobile.
+      const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
+      if (mobileMenuButton === null || !mobileMenuButton.classList.contains("open")) {
+        return;
+      }
 
-        const links = document.querySelectorAll(".mobile.navbar-links a");
-        const bot = links[links.length - 1];
-        const top = document.querySelector(".mobile.navbar-menu button");
+      const links = document.querySelectorAll(".mobile.navbar-links a");
+      const bot = links[links.length - 1];
+      const top = document.querySelector(".mobile.navbar-menu button");
 
-        // Do nothing if there is a missing focus element.
-        if (top === null || bot === undefined) {
-          return;
-        }
+      // Do nothing if there is a missing focus element.
+      if (top === null || bot === undefined) {
+        return;
+      }
 
-        // Wrap the focus to the top or bottom element if needed. The direction
-        // of the wrapping depends on whether TAB or SHIFT + TAB is pressed.
-        if (!event.shiftKey && document.activeElement === bot) {
-          top.focus();
-          event.preventDefault();
-        } else if (event.shiftKey && document.activeElement === top) {
-          bot.focus();
-          event.preventDefault();
-        }
+      const forward = (
+        // TAB
+        (!event.shiftKey && event.keyCode == 9) ||
+        // OPTION + COMMAND + RIGHT
+        (event.metaKey && event.altKey && event.keyCode == 39)
+      );
+
+      const backward = (
+        // SHIFT + TAB
+        (event.shiftKey && event.keyCode == 9) ||
+        // OPTION + COMMAND + LEFT
+        (event.metaKey && event.altKey && event.keyCode == 37)
+      );
+
+      // Wrap the focus to the top or bottom element if needed. The direction
+      // of the wrapping depends on the direction of navigation.
+      if (forward && document.activeElement === bot) {
+        top.focus();
+        event.preventDefault();
+      } else if (backward && document.activeElement === top) {
+        bot.focus();
+        event.preventDefault();
       }
     });
   </script>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -423,15 +423,14 @@
   <!-- Utility functions for setting ARIA attributes on buttons that show menus. -->
   <script type="text/javascript">
     function setAriaAttributes(button, expand) {
-      console.log("setAriaAttributes()", button, expand);
-      const skip = button.ariaLabel.indexOf(" ");
-      const menu = button.ariaLabel.substr(skip);
-      button.ariaLabel = (expand ? "close" : "open") + menu;
-      button.ariaExpanded = expand.toString();
+      const skip = button.getAttribute("aria-label").indexOf(" ");
+      const menu = button.getAttribute("aria-label").substr(skip);
+      button.setAttribute("aria-label", (expand ? "close" : "open") + menu);
+      button.setAttribute("aria-expanded", expand.toString());
     }
 
     function toggleAriaAttributes(button) {
-      setAriaAttributes(button, button.ariaExpanded === "false");
+      setAriaAttributes(button, button.getAttribute("aria-expanded") === "false");
     }
   </script>
 
@@ -445,12 +444,10 @@
         const button = link.querySelector("button");
         if (dropdown !== null) {
           timers[i] = {link: link, button: button, timeout: undefined};
-          console.log("for", i, timers[i]);
 
           // Expands the current dropdown and closes other dropdowns.
           const expandDropdown = () => {
             for (const [j, timer] of Object.entries(timers)) {
-              console.log("expandDropdown()", i, j, timer);
               clearTimeout(timer.timeout);
               if (i !== j) {
                 timer.link.classList.remove("open");
@@ -464,7 +461,6 @@
           // Closes the current dropdown after the given delay.
           const collapseDropdown = (event, delay = 1000) => {
             timers[i].timeout = setTimeout(function(event){
-              console.log("collapseDropdown()", i, link, button, timers[i].timeout);
               link.classList.remove("open");
               setAriaAttributes(button, false);
             }, delay);

--- a/xanadu_sphinx_theme/theme.conf
+++ b/xanadu_sphinx_theme/theme.conf
@@ -70,7 +70,7 @@ footer_about =
 footer_policies =
 # Column links to display in the footer
 footer_links =
-# Social media links and icons to be displayed in the footer
+# Social media names, links, and icons to be displayed in the footer
 footer_social_icons =
 # Taglines to be displayed under the social media links in the footer
 footer_taglines =

--- a/xanadu_sphinx_theme/theme.conf
+++ b/xanadu_sphinx_theme/theme.conf
@@ -6,10 +6,11 @@ sidebars = searchbox.html, globaltoc.html
 [options]
 # Name of the project to appear in the navigation bar.
 navbar_name =
-# Path to an image with the project name and wordmark to appear in the
-# navigation bar. Specifying this option will replace the project name and logo
-# in the navigation bar.
+# Path to an image with the project name and wordmark to appear in the navigation bar.
+# Specifying this option will replace the project name and logo in the navigation bar.
 navbar_wordmark_path =
+# Alternative text to display in lieu of the wordmark or logo in the navigation bar.
+navbar_logo_alt =
 # Path to the project logo to appear in the navigation bar.
 navbar_logo_path = _static/xanadu_logo.svg
 # Colour of the auto-generated Xanadu (X) logo (available at ``_static/xanadu_logo.svg``).


### PR DESCRIPTION
**Context:**

There were a number of accessibility issues introduced in v0.4.0 of the XST, including:

* Missing `alt` text for navbar images.
* Missing ARIA labels for `<a>` and `<button>` elements.
* Missing `ENTER` and `ECS` controls for menu buttons.
* Focus is not trapped within the expanded navbar menu on mobile.

**Description of the Change:**

This PR addresses all of the issues in the context. It also introduces:
1. An optional `navbar_logo_alt` theme option to control the alternative text in the navbar.
2. A mandatory `name` field to the social icons in the footer to populate ARIA labels.

The version number is also bumped to v0.5.0 to account for (2) above.

**Benefits:**

* The XST footer and navbar are more accessible to those using keyboard navigation or screen readers.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

None.

---

**Previews:**
* Xanadu Sphinx Theme - https://xanadu-sphinx-theme--44.org.readthedocs.build/en/44/.
* PennyLane Sphinx Theme - https://xanaduai-pennylane--40.com.readthedocs.build/projects/sphinx-theme/en/40/.