### PR TITLE
Embed Command Palette into `xanadu-sphinx-theme` w/ enable flag

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,16 @@
-## Release 0.7.0 (development release)
+## Release 0.7.0
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Alan Martin](https://github.com/alan-emartin),
+
+## Features
+
+* Embedded `pennylane-command-palette`, created button ui, and added a new
+  `command_palette_enabled` option to the theme. [(#57)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/57)
+
 
 ## Release 0.6.2 
 

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,10 @@ the ``html_theme_options`` dictionary in your ``conf.py`` file.
     If ``True``, navigating to ``search.html`` (or using the search box) will redirect
     users to https://pennylane.ai/search with the appropriate query parameters.
 
+``command_palette_enabled``
+    When set to ``True``, the command palette is activated, enabling users to easily
+    search and navigate all content within pennylane.ai.
+
 Navigation Bar
 --------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,6 +99,7 @@ html_favicon = "_static/favicon.ico"
 
 # Xanadu theme options (see theme.conf for more information).
 html_theme_options = {
+    "command_palette_enabled": False,
     "navbar_name": "Xanadu Sphinx Theme",
     "navbar_logo_colour": "#f48fb1",
     "navbar_left_links": [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,7 +99,7 @@ html_favicon = "_static/favicon.ico"
 
 # Xanadu theme options (see theme.conf for more information).
 html_theme_options = {
-    "command_palette_enabled": True,
+    "command_palette_enabled": False,
     "navbar_name": "Xanadu Sphinx Theme",
     "navbar_logo_colour": "#f48fb1",
     "navbar_left_links": [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,7 +99,7 @@ html_favicon = "_static/favicon.ico"
 
 # Xanadu theme options (see theme.conf for more information).
 html_theme_options = {
-    "command_palette_enabled": False,
+    "command_palette_enabled": True,
     "navbar_name": "Xanadu Sphinx Theme",
     "navbar_logo_colour": "#f48fb1",
     "navbar_left_links": [

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -1,3 +1,9 @@
+<!-- Command Palette WC -->
+<pennylane-help></pennylane-help>
+<!-- Command Palette Script -->
+ <script type="module" src="http://localhost:4173/assets/js/widget.js"></script>
+ <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
+
 <nav>
   <!-- Logo and Title -->
 

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -234,7 +234,6 @@
 
   /* Detect User OS */
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-  console.log(`User OS: ${isMac ? 'Mac' : 'Windows'}`);
 
   /* Set OS Label */
   const OSLabel = document.getElementById('os-label');

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -80,6 +80,11 @@
       {% endfor %}
     </ul>
     <ul class="navbar-right-links desktop">
+      <button class="command-palette-button desktop" onclick="openCommandPalette()" aria-label="open command palette">
+        <i class="bx bx-search"></i>
+        <span>Search</span>
+        <span id="os-label"></span>
+      </button>
       {% for link in theme_navbar_right_links %}
         {{
           render_desktop_navbar_right_link(
@@ -196,7 +201,6 @@
           )
       }}
     {% endfor %}
-    <div id="os-label"></div>
   </ul>
 </div>
 
@@ -225,7 +229,7 @@
 
   /* Set OS Label */
   const OSLabel = document.getElementById('os-label');
-  OSLabel.innerHTML = isMac ? `${macShortcut}` : `${desktopShortcut}`;
+  OSLabel.innerHTML = isMac ? macShortcut : desktopShortcut;
 
   /* Open Handler */
   function openCommandPalette() {

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -81,9 +81,10 @@
     </ul>
     <ul class="navbar-right-links desktop">
       <button class="command-palette-button desktop" onclick="openCommandPalette()" aria-label="open command palette">
-        <i class="bx bx-search"></i>
         <span>Search</span>
-        <span id="os-label"></span>
+        <span class="command-palette-button-shortcut">
+          <span id="os-label"></span>
+        </span>
       </button>
       {% for link in theme_navbar_right_links %}
         {{
@@ -211,7 +212,7 @@
  <script type="module" src="http://localhost:4173/assets/js/widget.js"></script>
  <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
 
-<script defer>
+<script>
   /* Close on ESC keydown */
   document.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -1,9 +1,3 @@
-<!-- Command Palette WC -->
-<pennylane-help></pennylane-help>
-<!-- Command Palette Script -->
- <script type="module" src="http://localhost:4173/assets/js/widget.js"></script>
- <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
-
 <nav>
   <!-- Logo and Title -->
 
@@ -202,5 +196,39 @@
           )
       }}
     {% endfor %}
+    <div id="os-label"></div>
   </ul>
 </div>
+
+<!-- Command Palette WC -->
+<pennylane-help></pennylane-help>
+
+<!-- Command Palette Script -->
+ <script type="module" src="http://localhost:4173/assets/js/widget.js"></script>
+ <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
+
+<script defer>
+  /* Close on ESC keydown */
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      window.postMessage("command-palette:close", "*");
+    }
+  }); 
+
+  /* Open on Keyboard Shortcut */
+  const desktopShortcut = "Ctrl + K";
+  const macShortcut = "⌘ + K";
+
+  /* Detect User OS */
+  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  console.log(`User OS: ${isMac ? 'Mac' : 'Windows'}`);
+
+  /* Set OS Label */
+  const OSLabel = document.getElementById('os-label');
+  OSLabel.innerHTML = isMac ? `${macShortcut}` : `${desktopShortcut}`;
+
+  /* Open Handler */
+  function openCommandPalette() {
+    window.postMessage("command-palette:open", "*");
+  }
+</script>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -222,9 +222,9 @@
   
   <!-- Initialize Command Palette Widget -->
   <pennylane-help></pennylane-help>
-  <!-- <script type="module" src="https://widget.dev.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
+  <script type="module" src="https://widget.dev.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script>
   <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> --> 
-  <script type="module" src="http://localhost:4173/assets/js/widget.js"></script>
+  <!-- <script type="module" src="http://localhost:4173/assets/js/widget.js"></script> -->
 
   <script>
     /* OS Detection */

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -216,8 +216,8 @@
   }); 
 
   /* Open on Keyboard Shortcut */
-  const desktopShortcut = "Ctrl + K";
-  const macShortcut = "⌘ + K";
+  const desktopShortcut = "Ctrl+K";
+  const macShortcut = "⌘K";
 
   /* Detect User OS */
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -80,12 +80,15 @@
       {% endfor %}
     </ul>
     <ul class="navbar-right-links desktop">
-      <button class="command-palette-button desktop" onclick="openCommandPalette()" aria-label="open command palette">
-        <span>Search</span>
-        <span class="command-palette-button-shortcut">
-          <span id="os-label"></span>
-        </span>
-      </button>
+      {% if theme_command_palette_enabled %}
+        <!-- Command Palette Button - Desktop -->
+        <button class="command-palette-button desktop" onclick="openCommandPalette()" aria-label="open command palette">
+          <span>Search</span>
+          <span class="command-palette-button-shortcut">
+            <span id="os-label"></span>
+          </span>
+        </button>
+      {% endif %}
       {% for link in theme_navbar_right_links %}
         {{
           render_desktop_navbar_right_link(
@@ -173,13 +176,15 @@
 
 <div class="navbar-links mobile">
   <ul>
-    <!-- Command Palette Search Button -->
-    <li class="navbar-link mobile">
-      <button class="command-palette-button mobile" onclick="openCommandPalette()" aria-label="open command palette">
-        <i class="bx bx-search command-palette-button-icon"></i>
-        <span>Search</span>
-      </button>
-    </li>
+    {% if theme_command_palette_enabled %}
+      <!-- Command Palette Button - Mobile -->
+      <li class="navbar-link mobile">
+        <button class="command-palette-button mobile" onclick="openCommandPalette()" aria-label="open command palette">
+          <i class="bx bx-search command-palette-button-icon"></i>
+          <span>Search</span>
+        </button>
+      </li>
+    {% endif %}
 
     {% for link in theme_navbar_left_links %}
       {{
@@ -213,34 +218,31 @@
   </ul>
 </div>
 
-<!-- Command Palette WC -->
-<pennylane-help></pennylane-help>
+{% if theme_command_palette_enabled %}
+  
+  <!-- Initialize Command Palette Widget -->
+  <pennylane-help></pennylane-help>
+  <!-- <script type="module" src="https://widget.dev.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
+  <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> --> 
+  <script type="module" src="http://localhost:4173/assets/js/widget.js"></script>
 
-<!-- Command Palette Script -->
- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script>
- <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
+  <script>
+    /* OS Detection */
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    const desktopShortcut = "Ctrl+K";
+    const macShortcut = "⌘K";
+    const OSLabel = document.getElementById('os-label');
+    OSLabel.innerHTML = isMac ? macShortcut : desktopShortcut;
 
-<script>
-  /* Close on ESC keydown */
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      window.postMessage("command-palette:close", "*");
+    /* Open Handler */
+    function openCommandPalette() {
+      window.postMessage("command-palette:open", "*");
     }
-  }); 
-
-  /* Open on Keyboard Shortcut */
-  const desktopShortcut = "Ctrl+K";
-  const macShortcut = "⌘K";
-
-  /* Detect User OS */
-  const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-
-  /* Set OS Label */
-  const OSLabel = document.getElementById('os-label');
-  OSLabel.innerHTML = isMac ? macShortcut : desktopShortcut;
-
-  /* Open Handler */
-  function openCommandPalette() {
-    window.postMessage("command-palette:open", "*");
-  }
-</script>
+    /* Close on ESC Handler */
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        window.postMessage("command-palette:close", "*");
+      }
+    }); 
+  </script>
+{% endif %}

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -173,6 +173,14 @@
 
 <div class="navbar-links mobile">
   <ul>
+    <!-- Command Palette Search Button -->
+    <li class="navbar-link mobile">
+      <button class="command-palette-button mobile" onclick="openCommandPalette()" aria-label="open command palette">
+        <i class="bx bx-search command-palette-button-icon"></i>
+        <span>Search</span>
+      </button>
+    </li>
+
     {% for link in theme_navbar_left_links %}
       {{
           render_mobile_navbar_link(

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -217,7 +217,7 @@
 <pennylane-help></pennylane-help>
 
 <!-- Command Palette Script -->
- <script type="module" src="http://localhost:4173/assets/js/widget.js"></script>
+ <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script>
  <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> -->
 
 <script>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -82,7 +82,12 @@
     <ul class="navbar-right-links desktop">
       {% if theme_command_palette_enabled %}
         <!-- Command Palette Button - Desktop -->
-        <button class="command-palette-button desktop" onclick="openCommandPalette()" aria-label="open command palette">
+        <button 
+          type="button" 
+          class="command-palette-button desktop" 
+          onclick="openCommandPalette()" 
+          aria-label="open command palette"
+        >
           <span>Search</span>
           <span class="command-palette-button-shortcut">
             <span id="os-label"></span>
@@ -179,7 +184,12 @@
     {% if theme_command_palette_enabled %}
       <!-- Command Palette Button - Mobile -->
       <li class="navbar-link mobile">
-        <button class="command-palette-button mobile" onclick="openCommandPalette()" aria-label="open command palette">
+        <button 
+          type="button" 
+          class="command-palette-button mobile" 
+          onclick="openCommandPalette()" 
+          aria-label="open command palette"
+        >
           <i class="bx bx-search command-palette-button-icon"></i>
           <span>Search</span>
         </button>
@@ -219,15 +229,12 @@
 </div>
 
 {% if theme_command_palette_enabled %}
-  
   <!-- Initialize Command Palette Widget -->
   <pennylane-help></pennylane-help>
-  <script type="module" src="https://widget.dev.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script>
-  <!-- <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> --> 
-  <!-- <script type="module" src="http://localhost:4173/assets/js/widget.js"></script> -->
+  <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> 
 
-  <script>
-    /* OS Detection */
+  <script type="text/javascript">
+    /* OS Detection & Shortcut Logic */
     const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
     const desktopShortcut = "Ctrl+K";
     const macShortcut = "⌘K";
@@ -243,6 +250,6 @@
       if (event.key === 'Escape') {
         window.postMessage("command-palette:close", "*");
       }
-    }); 
+    });
   </script>
 {% endif %}

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3851,3 +3851,26 @@ p.sphx-glr-signature a.reference.external {
   border: {{ theme_toc_marker_colour }} solid 1px;
   color: #fff;
 }
+
+/* Command Palette Button */
+/*------------------------------*/
+.command-palette-button {
+  align-items: center;
+  border-radius: 5px;
+  border: 1px solid #cfcfcf;
+  display: flex;
+  gap: 5px;
+  height: 36px;
+  padding: 0;
+}
+
+.command-palette-button span {
+  color: #9e9e9e;
+  font-family: "Roboto", sans-serif;
+  font-size: 14px;
+  line-height: 140%;
+}
+
+.os-label {
+ 
+}

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3862,10 +3862,19 @@ p.sphx-glr-signature a.reference.external {
   background-color: #fff;
   border-radius: 5px;
   border: 1px solid #cfcfcf;
-  gap: 10px;
+  gap: 5px;
   height: 36px;
   transition: all 0.3s;
-  width: 140px;
+}
+
+.command-palette-button.desktop {
+  width: fit-content;
+}
+
+.command-palette-button.mobile {
+  width: 100%;
+  gap: 5px;
+  justify-content: flex-start;
 }
 
 .command-palette-button:hover,
@@ -3880,16 +3889,19 @@ p.sphx-glr-signature a.reference.external {
   line-height: 140%;
 }
 
+.command-palette-button-icon {
+  color: #9e9e9e;
+  font-size: 20px;
+}
+
 .command-palette-button-shortcut {
   background-color: #f1f1f1;
   border-radius: 5px;
   padding: 1px 4px;
 }
 
-/* Command Palette Button - XL MQ */
-/*--------------------------------*/
 @media (max-width: 1280px) {
-  .command-palette-button {
+  .command-palette-button.desktop {
     width: fit-content;
   }
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3868,7 +3868,7 @@ p.sphx-glr-signature a.reference.external {
 }
 
 .command-palette-button.desktop {
-  width: fit-content;
+  width: 140px;
 }
 
 .command-palette-button.mobile {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -1961,6 +1961,7 @@ nav {
 ----------------------------------------------------------------------------- */
 
 .desktop.navbar-right-links {
+  align-items: center;
   display: flex;
   flex-direction: row;
   gap: 16px;
@@ -3855,13 +3856,21 @@ p.sphx-glr-signature a.reference.external {
 /* Command Palette Button */
 /*------------------------------*/
 .command-palette-button {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
+  background-color: #fff;
   border-radius: 5px;
   border: 1px solid #cfcfcf;
-  display: flex;
-  gap: 5px;
+  gap: 10px;
   height: 36px;
-  padding: 0;
+  transition: all 0.3s;
+  width: 140px;
+}
+
+.command-palette-button:hover,
+.command-palette-button:focus-visible {
+  background-color: #f1f1f1;
 }
 
 .command-palette-button span {
@@ -3871,6 +3880,16 @@ p.sphx-glr-signature a.reference.external {
   line-height: 140%;
 }
 
-.os-label {
- 
+.command-palette-button-shortcut {
+  background-color: #f1f1f1;
+  border-radius: 5px;
+  padding: 1px 4px;
+}
+
+/* Command Palette Button - XL MQ */
+/*--------------------------------*/
+@media (max-width: 1280px) {
+  .command-palette-button {
+    width: fit-content;
+  }
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3882,6 +3882,10 @@ p.sphx-glr-signature a.reference.external {
   background-color: #f1f1f1;
 }
 
+.command-palette-button:focus {
+  outline: none;
+}
+
 .command-palette-button span {
   color: #9e9e9e;
   font-family: "Roboto", sans-serif;

--- a/xanadu_sphinx_theme/theme.conf
+++ b/xanadu_sphinx_theme/theme.conf
@@ -61,6 +61,9 @@ extra_copyrights =
 # Whether to redirect searches to https://pennylane.ai/search.
 search_on_pennylane_ai = False
 
+# Whether to enable the pennylane command palette. 
+command_palette_enabled = False
+
 # GitHub organization and repository name of associated GitHub repo.
 # Used to ensure that 'View on GitHub' buttons work.
 github_repo =


### PR DESCRIPTION
**Context:**
- Embedded `pennylane-command-palette` for global search interface.

**Description of the Change:**
- Embedded production script for `pennylane-command-palette`.
- Created mobile and desktop button for opening `pennylane-command-palette`.
- Created event listener for closing, and function for opening command palette.
- Created OS detection logic using navigator and dynamic command label logic.
- Created theme configuration for enabling and disabling the command palette.

**Benefits:**
- Enables global search of PennyLane content from docs site

**Possible Drawbacks:**
- None

**Related GitHub Issues:**
- None
