### PR TITLE
update check to look for `string` 'true' not `bool`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,7 +8,7 @@ This release contains contributions from (in alphabetical order):
 
 ### Bug fixes
 
-* fixed an issue with the `command_palette_enabled` and `search_on_pennylane` options
+* Fixed an issue with the `command_palette_enabled` and `search_on_pennylane` options
   having falsey values, big thanks to [Mikhail Andrenkov](https://github.com/Mandrenkov).
   [(#60)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/60)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,6 +16,7 @@ This release contains contributions from (in alphabetical order):
 
 ### Contributors
 
+This release contains contributions from (in alphabetical order):
 
 [Alan Martin](https://github.com/alan-emartin),
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,14 +1,21 @@
-## Release 0.8.0 (development release)
+## Release 0.7.1
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+- [Alan Martin](https://github.com/alan-emartin)
+
+### Bug fixes
+
+* fixed an issue with the `command_palette_enabled` and `search_on_pennylane` options
+  having falsey values, big thanks to [Mikhail Andrenkov](https://github.com/Mandrenkov).
+  [(#60)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/60)
 
 ## Release 0.7.0
 
 ### Contributors
 
-This release contains contributions from (in alphabetical order):
 
 [Alan Martin](https://github.com/alan-emartin),
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -99,7 +99,7 @@ html_favicon = "_static/favicon.ico"
 
 # Xanadu theme options (see theme.conf for more information).
 html_theme_options = {
-    "command_palette_enabled": False,
+    "command_palette_enabled": True,
     "navbar_name": "Xanadu Sphinx Theme",
     "navbar_logo_colour": "#f48fb1",
     "navbar_left_links": [

--- a/xanadu_sphinx_theme/_version.py
+++ b/xanadu_sphinx_theme/_version.py
@@ -3,4 +3,4 @@ This module specifies the Xanadu Sphinx Theme version with https://semver.org/
 using the following format: <major>.<minor>.<patch>[-<pre-release>].
 """
 
-__version__ = "0.8.0-dev"
+__version__ = "0.7.1"

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -80,7 +80,7 @@
       {% endfor %}
     </ul>
     <ul class="navbar-right-links desktop">
-      {% if theme_command_palette_enabled %}
+      {% if theme_command_palette_enabled|lower == 'true' %}
         <!-- Command Palette Button - Desktop -->
         <button 
           type="button" 
@@ -181,7 +181,7 @@
 
 <div class="navbar-links mobile">
   <ul>
-    {% if theme_command_palette_enabled %}
+    {% if theme_command_palette_enabled|lower == 'true' %}
       <!-- Command Palette Button - Mobile -->
       <li class="navbar-link mobile">
         <button 
@@ -228,7 +228,7 @@
   </ul>
 </div>
 
-{% if theme_command_palette_enabled %}
+{% if theme_command_palette_enabled|lower == 'true' %}
   <!-- Initialize Command Palette Widget -->
   <pennylane-help></pennylane-help>
   <script type="module" src="https://widget.cloud.pennylane.ai/command-palette/assets/js/widget.js"></script> 

--- a/xanadu_sphinx_theme/search.html
+++ b/xanadu_sphinx_theme/search.html
@@ -1,4 +1,4 @@
-{% if theme_search_on_pennylane_ai %}
+{% if theme_search_on_pennylane_ai|lower == 'true' %}
   <!-- If JavaScript is enabled, redirect users to https://pennylane.ai/search. -->
   <script type="text/javascript">
     const search_version = window.location.pathname.includes("/latest/") ? "latest" : "stable";


### PR DESCRIPTION
**Context:**
- PST theme configurations were ignored, causing command palette to appear even though it was configured to be disabled.

**Description of the Change:**
- Use string values of `true` in XST

**Benefits:**
- N/A

**Possible Drawbacks:**
- N/A

**Related GitHub Issues:**
- N/A