### PR TITLE
SC84027 | `project` Filter Is Included In Search Query

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,14 @@
-## Release 0.9.0 (development release)
+## Release 0.9.0
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+- [Andrew Gardhouse](https://github.com/AndrewGardhouse)
+
+### Features
+
+- Project filter is now passed to search options when `search_on_pennylane_ai` is `True`
 
 ## Release 0.8.0
 

--- a/xanadu_sphinx_theme/search.html
+++ b/xanadu_sphinx_theme/search.html
@@ -1,9 +1,23 @@
 {% if theme_search_on_pennylane_ai|lower == 'true' %}
   <!-- If JavaScript is enabled, redirect users to https://pennylane.ai/search. -->
   <script type="text/javascript">
+    const DOC_PROJECTS = [
+      { urlPath: '/projects/catalyst/', project: 'catalyst' },
+      { urlPath: '/projects/lightning/', project: 'pennylane-lightning' },
+      { urlPath: '/projects/qiskit/', project: 'pennylane-qiskit' },
+    ]
+
     const search_version = window.location.pathname.includes("/latest/") ? "latest" : "stable";
     const search_query = new URLSearchParams(window.location.search).get("q") || "";
-    const search_options = {contentType: "DOC", q: search_query, version: search_version};
+    const search_project = DOC_PROJECTS.find((project) => {
+      return window.location.pathname.includes(project.urlPath)
+    })
+    const search_options = {
+      contentType: 'DOC',
+      q: search_query,
+      version: search_version,
+      project: search_project ? search_project.project : 'pennylane',
+    }
 
     const redirect_page = "https://pennylane.ai/search";
     const redirect_query_params = Object.entries(search_options).map(([k, v]) => `${k}=${v}`).join("&");


### PR DESCRIPTION
**Context:**
https://app.shortcut.com/xanaduai/story/84027/update-docs-theme-to-accept-project-search-filter

**Description of the Change:**
- `project` filter is passed to search query, so only the current project is included in search results

**Benefits:**
- More accurate search results

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A