### PR TITLE
Update Project Filter

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,12 @@
-## Release 0.11.0 (development release)
+## Release 0.11.0
 
 ### Contributors
 
-This release contains contributions from (in alphabetical order):
+- [Andrew Gardhouse](https://github.com/AndrewGardhouse)
+
+### Features
+
+- Update `project` filter to `projects`
 
 ## Release 0.10.0
 

--- a/xanadu_sphinx_theme/search.html
+++ b/xanadu_sphinx_theme/search.html
@@ -2,9 +2,9 @@
   <!-- If JavaScript is enabled, redirect users to https://pennylane.ai/search. -->
   <script type="text/javascript">
     const DOC_PROJECTS = [
-      { urlPath: '/projects/catalyst/', project: 'catalyst' },
-      { urlPath: '/projects/lightning/', project: 'pennylane-lightning' },
-      { urlPath: '/projects/qiskit/', project: 'pennylane-qiskit' },
+      { urlPath: '/projects/catalyst/', projects: 'catalyst' },
+      { urlPath: '/projects/lightning/', projects: 'pennylane-lightning' },
+      { urlPath: '/projects/qiskit/', projects: 'pennylane-qiskit' },
     ]
 
     const search_version = window.location.pathname.includes("/latest/") ? "latest" : "stable";


### PR DESCRIPTION
**Context:**
https://app.shortcut.com/xanaduai/story/84027/update-docs-theme-to-accept-project-search-filter

**Description of the Change:**
- `project` filter is renamed to `projects`

**Benefits:**
- More accurate search results

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A