### PR TITLE
XST: sc-95849-docs-missing-local-table-of-contents

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,7 +8,7 @@ This release contains contributions from (in alphabetical order):
 
 ### Bug fixes
 
-- Fixed an issue where local table of contents was missing in Catalyst documentation [(#PR_NUMBER)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/PR_NUMBER)
+- Fixed an issue where local table of contents was missing in Catalyst documentation 
 
 ## Release 0.16.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,14 @@
-## Release 0.17.0 (development release)
+## Release 0.17.0
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Ashish Kanwar Singh](https://github.com/ashishks0522)
+
+### Bug fixes
+
+- Fixed an issue where local table of contents was missing in Catalyst documentation [(#PR_NUMBER)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/PR_NUMBER)
 
 ## Release 0.16.0
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,7 +20,7 @@ This release contains contributions from (in alphabetical order):
 
 ### Features
 
-- Added Google Analytics event tracking functionality [(#PR_NUMBER)](https://github.com/XanaduAI/xanadu-sphinx-theme/pull/PR_NUMBER)
+- Added Google Analytics event tracking functionality 
   - Implemented `sendCustomGAEvent` function for tracking user interactions
   - Added safe no-op function when GA is disabled
   - Added event tracking for navbar and footer interactions

--- a/xanadu_sphinx_theme/localtoc.html
+++ b/xanadu_sphinx_theme/localtoc.html
@@ -1,37 +1,22 @@
-{% if (pagename != "search") %}
+<!-- Only display the local table of contents if we are not on the search page -->
+{% if pagename != "search" %}
 <div class="localtoc-container nano has-scrollbar">
   <div class="nano-content">
     <div id="localtoc">
-        {% if display_toc %}
-          <h3>Contents</h3>
-          <!-- Display the ToC for the current document if it is not empty. -->
-          {{ toc | replace("<li>", "<li class='current'>")
-                 | replace("<ul>", "<ul class='current'>")}}
-        {% elif theme_toc_subset %}
-          <h3>Contents</h3>
-          <!-- Display the ToC for a subset of the current document tree. -->
-          {{ toctree(maxdepth=3, collapse=True, includehidden=True) }}
+      <!-- Generate the HTML for the toctree with a maximum depth of 3, collapsed, and including hidden items -->
+      {% set toc_html = toctree(maxdepth=3, collapse=True, includehidden=True) %}
+      <!-- If a subset of the ToC should be shown, and the generated ToC is not empty and contains level 2 items -->
+      {% if theme_toc_subset and toc_html.strip() and 'toctree-l2' in toc_html %}
+        <h3>Contents</h3>
+        <!-- Display the ToC for a subset of the current document tree. -->
+        {{ toctree(maxdepth=3, collapse=True, includehidden=True) }}
+      {% else %}
+        <!-- This checks if the 'toc' (table of contents) variable exists and is not just whitespace. If so, the local table of contents will be displayed below. -->
+        {% if toc and toc.strip() %}
+        <h3>Contents</h3>
+          {{ toc }}
         {% endif %}
-    </div>
-
-    <div class="xanadu-call-to-action-links">
-        <h3>Downloads</h3>
-        <div id="tutorial-type">{{ pagename }}</div>
-        <div class="download-python-link">
-            <i class="fab fa-python"></i>&nbsp;
-            <div class="call-to-action-desktop-view">Download Python script</div>
-        </div>
-        <div class="download-notebook-link">
-            <i class="fas fa-download"></i>&nbsp;
-            <div class="call-to-action-desktop-view">Download Notebook</div>
-        </div>
-        <div class="github-view-link">
-            <i class="fab fa-github"></i>&nbsp;
-            <div class="call-to-action-desktop-view">View on GitHub</div>
-        </div>
-    </div>
-    <div id="related-tutorials" class="mt-4">
-      <h3> Related</h3>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/xanadu_sphinx_theme/localtoc.html
+++ b/xanadu_sphinx_theme/localtoc.html
@@ -6,13 +6,13 @@
       <!-- Generate the HTML for the toctree with a maximum depth of 3, collapsed, and including hidden items -->
       {% set toc_html = toctree(maxdepth=3, collapse=True, includehidden=True) %}
       <!-- If a subset of the ToC should be shown, and the generated ToC is not empty and contains level 2 items -->
-      {% if theme_toc_subset and toc_html.strip() %}
+      {% if theme_toc_subset and toc_html.strip() and 'class="current"' in toc_html %}
         <h3>Contents</h3>
         <!-- Display the ToC for a subset of the current document tree. -->
         {{ toctree(maxdepth=3, collapse=True, includehidden=True) }}
       {% else %}
         <!-- This checks if the 'toc' (table of contents) variable exists and is not just whitespace. If so, the local table of contents will be displayed below. -->
-        {% if toc and toc.strip() %}
+        {% if toc and toc.strip() and 'class="current"' in toc %}
         <h3>Contents</h3>
           {{ toc }}
         {% endif %}

--- a/xanadu_sphinx_theme/localtoc.html
+++ b/xanadu_sphinx_theme/localtoc.html
@@ -9,7 +9,7 @@
       {% if theme_toc_subset and toc_html.strip() and 'class="current"' in toc_html %}
         <h3>Contents</h3>
         <!-- Display the ToC for a subset of the current document tree. -->
-        {{ toctree(maxdepth=3, collapse=True, includehidden=True) }}
+        {{ toc_html }}
       {% else %}
         <!-- This checks if the 'toc' (table of contents) variable exists and is not just whitespace. If so, the local table of contents will be displayed below. -->
         {% if toc and toc.strip() and 'class="current"' in toc %}

--- a/xanadu_sphinx_theme/localtoc.html
+++ b/xanadu_sphinx_theme/localtoc.html
@@ -2,24 +2,22 @@
 {% if pagename != "search" %}
 <div class="localtoc-container nano has-scrollbar">
   <div class="nano-content">
+    <div id="localtoc">
       <!-- Generate the HTML for the toctree with a maximum depth of 3, collapsed, and including hidden items -->
       {% set toc_html = toctree(maxdepth=3, collapse=True, includehidden=True) %}
       <!-- If a subset of the ToC should be shown, and the generated ToC is not empty and contains level 2 items -->
       {% if theme_toc_subset and toc_html.strip() %}
-      <div id="globaltoc">
         <h3>Contents</h3>
         <!-- Display the ToC for a subset of the current document tree. -->
         {{ toctree(maxdepth=3, collapse=True, includehidden=True) }}
-      </div>
       {% else %}
         <!-- This checks if the 'toc' (table of contents) variable exists and is not just whitespace. If so, the local table of contents will be displayed below. -->
         {% if toc and toc.strip() %}
-        <div id="localtoc">
-          <h3>Contents</h3>
-            {{ toc }}
-        </div>
+        <h3>Contents</h3>
+          {{ toc }}
         {% endif %}
       {% endif %}
+    </div>
   </div>
 </div>
 {% endif %}

--- a/xanadu_sphinx_theme/localtoc.html
+++ b/xanadu_sphinx_theme/localtoc.html
@@ -2,22 +2,24 @@
 {% if pagename != "search" %}
 <div class="localtoc-container nano has-scrollbar">
   <div class="nano-content">
-    <div id="localtoc">
       <!-- Generate the HTML for the toctree with a maximum depth of 3, collapsed, and including hidden items -->
       {% set toc_html = toctree(maxdepth=3, collapse=True, includehidden=True) %}
       <!-- If a subset of the ToC should be shown, and the generated ToC is not empty and contains level 2 items -->
-      {% if theme_toc_subset and toc_html.strip() and 'toctree-l2' in toc_html %}
+      {% if theme_toc_subset and toc_html.strip() %}
+      <div id="globaltoc">
         <h3>Contents</h3>
         <!-- Display the ToC for a subset of the current document tree. -->
         {{ toctree(maxdepth=3, collapse=True, includehidden=True) }}
+      </div>
       {% else %}
         <!-- This checks if the 'toc' (table of contents) variable exists and is not just whitespace. If so, the local table of contents will be displayed below. -->
         {% if toc and toc.strip() %}
-        <h3>Contents</h3>
-          {{ toc }}
+        <div id="localtoc">
+          <h3>Contents</h3>
+            {{ toc }}
+        </div>
         {% endif %}
       {% endif %}
-    </div>
   </div>
 </div>
 {% endif %}

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -880,6 +880,10 @@ border-radius: 7px;
   display: none;
 }
 
+#localtoc > ul > li:not(.current) {
+  display: none;
+}
+
 #localtoc > ul.current > li.current > a {
   display: none;
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -876,10 +876,6 @@ border-radius: 7px;
   display: none;
 }
 
-#localtoc > ul > li:not(.current) {
-  display: none;
-}
-
 #localtoc > ul.current > li.current > a {
   display: none;
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -884,10 +884,6 @@ border-radius: 7px;
   display: none;
 }
 
-#localtoc > ul.current > li.current > a {
-  display: none;
-}
-
 /* Next and Previous Links
 ----------------------------------------------------------------------------- */
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -876,6 +876,10 @@ border-radius: 7px;
   display: none;
 }
 
+#localtoc > ul > li:not(.current) {
+  display: none;
+}
+
 #localtoc > ul.current > li.current > a {
   display: none;
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -876,7 +876,7 @@ border-radius: 7px;
   display: none;
 }
 
-#localtoc > ul > li:not(.current) {
+#localtoc > ul:not(.current) {
   display: none;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -812,10 +812,6 @@ td:first-child {
   color: #515151;
 }
 
-#localtoc > ul:first-of-type > li > a{
-    display:none;
-}
-
 #localtoc ul > li > ul > li > ul {
     margin-top: -7px;
     margin-left: 20px;


### PR DESCRIPTION
## Changes
- [sc-95849-catalyst-docs-missing-local-table-of-contents](https://app.shortcut.com/xanaduai/story/95849/catalyst-docs-missing-local-table-of-contents-toc-sidebar-on-some-pages)

## Summary
This PR fixes an issue where the local table of contents was not displaying correctly in the Catalyst documentation. The fix modifies the localtoc.html template to ensure proper rendering of the local table of contents.

## Changes
- Updated the localtoc.html template to properly handle table of contents display logic
- Added conditional checks to ensure the local table of contents is displayed when appropriate
- Improved template structure with better comments and organization

## Related PRs
- https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/147
- https://github.com/PennyLaneAI/catalyst/pull/2010
- https://github.com/PennyLaneAI/pennylane/pull/8158

## Preview
- Catalyst: https://xanaduai-pennylane--2010.com.readthedocs.build/projects/catalyst/en/2010/
- PennyLane: https://xanaduai-pennylane--8158.com.readthedocs.build/en/8158/

## Testing
- Comapre preview to 
  - https://docs.pennylane.ai/projects/catalyst/en/stable/index.html
  - https://docs.pennylane.ai/en/stable/
- Check that Empty contents heading does not show on homepage
- Check that proper TOC shows up on various pages for Catalyst