### PR TITLE
XST: sc-110105-replace-all-jquery-in-xanadu-sphinx-theme-to

### DIFF
--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Minor:
-    # Only trigger automatic release when pre-release branch is merged into main
+    # Only trigger automatic release when pre-release branch is merged into master
     if: github.event.pull_request.merged == true && github.head_ref == 'pre-release-version-bump'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/create-release-tag-and-notes.yml
+++ b/.github/workflows/create-release-tag-and-notes.yml
@@ -1,0 +1,51 @@
+# This action creates automatic release for xanadu-sphinx-theme
+# when pre-release-version-bump branch is merged into master
+name: Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+
+jobs:
+  Minor:
+    # Only trigger automatic release when pre-release branch is merged into main
+    if: github.event.pull_request.merged == true && github.head_ref == 'pre-release-version-bump'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: Minor version for each merge
+        id: taggerDryRun
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DRY_RUN: true
+          DEFAULT_BUMP: minor
+
+      - name: echo new tag
+        run: |
+          echo "The next tag version will be: ${{ steps.taggerDryRun.outputs.new_tag }}"
+      - name: echo tag
+        run: |
+          echo "The current tag is: ${{ steps.taggerDryRun.outputs.tag }}"
+      - name: echo part
+        run: |
+          echo "The version increment was: ${{ steps.taggerDryRun.outputs.part }}"
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.taggerDryRun.outputs.new_tag }} --generate-notes --notes-start-tag ${{ steps.taggerDryRun.outputs.tag }}
+
+      - name: Trigger Post Release Workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: run-post-release-bump

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -1,9 +1,9 @@
 name: Post-Release Version Bump
 
 on:
-  release:
-    types:
-      - published
+  repository_dispatch:
+    types: [run-post-release-bump]
+  workflow_dispatch:
 
 jobs:
   post_release_version_bump:

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -1,10 +1,17 @@
 name: Pre-Release Version Bump
 
 on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
   pre_release_version_bump:
+    # Skip automated release-maintenance branches to avoid recursive bump PRs.
+    if: github.event.pull_request.merged == true && github.head_ref != 'post-release-version-bump' && github.head_ref != 'pre-release-version-bump'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,8 +1,7 @@
 name: Upload
 on:
-  release:
-    types:
-      - published
+  repository_dispatch:
+    types: [run-post-release-bump]
 
 jobs:
   upload:

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -18,7 +18,7 @@ Community Card
         :paper: https://example.com
         :code: https://code.com
 
-        An explanation of the work.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
 
 .. community-card::
@@ -28,7 +28,7 @@ Community Card
     :paper: https://example.com
     :code: https://code.com
 
-    An explanation of the work.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
 
 

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -31,6 +31,75 @@ Community Card
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
 
+.. code-block:: rst
+
+    .. raw:: html
+
+        <div class="row g-3">
+            <div class="col-lg-6 col-md-6 col-12">
+
+    .. community-card::
+        :title: Weighted SubSpace QAOA to find maximum graph cliques
+        :date: 03/07/2022
+        :author: John Smith, Jane Doe
+        :paper: https://example.com
+        :code: https://code.com
+
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+    .. raw:: html
+
+            </div>
+            <div class="col-lg-6 col-md-6 col-12">
+
+    .. community-card::
+        :title: Quantum-Train Long Short-Term Memory (QT-LSTM) for Wave Prediction
+        :date: 09/04/2024
+        :author: John Smith, Jane Doe
+        :paper: https://example.com
+        :code: https://example.com
+
+        In this demo we introduce our new Momentum-QNG optimization algorithm and benchmark it with Momentum and QNG.
+
+    .. raw:: html
+
+            </div>
+        </div>
+
+.. raw:: html
+
+    <div class="row g-3">
+        <div class="col-lg-6 col-md-6 col-12">
+
+.. community-card::
+    :title: Weighted SubSpace QAOA to find maximum graph cliques
+    :date: 03/07/2022
+    :author: John Smith, Jane Doe
+    :paper: https://example.com
+    :code: https://code.com
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+.. raw:: html
+
+        </div>
+        <div class="col-lg-6 col-md-6 col-12">
+
+.. community-card::
+    :title: Quantum-Train Long Short-Term Memory (QT-LSTM) for Wave Prediction
+    :date: 09/04/2024
+    :author: Lakshay Goel, Kovid Tandon
+    :paper: https://example.com
+    :code: https://example.com
+
+    In this demo we introduce our new Momentum-QNG optimization algorithm and benchmark it with Momentum and QNG.
+
+.. raw:: html
+
+        </div>
+    </div>
+
+
 
 Details Dropdown
 ----------------

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -235,6 +235,54 @@ Title Card
 
     <div style='clear:both'>
 
+.. code-block:: rst
+
+    .. raw:: html
+
+        <div class="row g-3">
+
+    .. title-card::
+        :name: Installation
+        :description: Install and configure PennyLane in development mode.
+        :link: guide/installation.html
+
+    .. title-card::
+        :name: Contribution guide
+        :description: How to get involved in the PennyLane community.
+        :link: guide/contributing.html
+
+    .. title-card::
+        :name: Software tests
+        :description: Running tests and measuring coverage for PennyLane.
+        :link: guide/tests.html
+
+    .. raw:: html
+
+        </div>
+
+.. raw:: html
+
+    <div class="row g-3">
+
+.. title-card::
+    :name: Installation
+    :description: Install and configure PennyLane in development mode.
+    :link: guide/installation.html
+
+.. title-card::
+    :name: Contribution guide
+    :description: How to get involved in the PennyLane community.
+    :link: guide/contributing.html
+
+.. title-card::
+    :name: Software tests
+    :description: Running tests and measuring coverage for PennyLane.
+    :link: guide/tests.html
+
+.. raw:: html
+
+    </div>
+
 YouTube Video
 -------------
 

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -161,21 +161,117 @@ Gallery Item
 
 .. code-block:: rest
 
+    .. raw:: html
+
+        <div class="gallery-grid">
+
     .. gallery-item::
-        :description: :doc:`Getting Started <started>`
-        :figure: :figure: _static/teleport.png
+        :description: Getting Started
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Installation
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Configuration
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: API Reference
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Development Guide - API
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Plugin Tutorials  Quantum Chemistry
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Device Docs
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Optimization
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Templates
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Demos
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Machine Learning
+        :figure: _static/teleport.png
+
+    .. gallery-item::
+        :description: Quantum Chemistry
+        :figure: _static/teleport.png
 
     .. raw:: html
 
-        <div style='clear:both'>
+        </div>
+
+.. raw:: html
+
+    <div class="gallery-grid">
 
 .. gallery-item::
-    :description: :doc:`Getting Started <started>`
+    :description: Getting Started
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Installation
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Configuration
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: API Reference
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Development Guide
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Plugin Tutorials
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Device Docs
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Optimization
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Templates
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Demos
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Machine Learning
+    :figure: _static/teleport.png
+
+.. gallery-item::
+    :description: Quantum Chemistry
     :figure: _static/teleport.png
 
 .. raw:: html
 
-    <div style='clear:both'>
+    </div>
 
 Index Card
 ----------

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -248,13 +248,33 @@ Title Card
 
     .. title-card::
         :name: Contribution guide
-        :description: How to get involved in the PennyLane community.
+        :description: How to get involved in the PennyLane community and start contributing through issues, discussions, and pull requests.
         :link: guide/contributing.html
 
     .. title-card::
         :name: Software tests
-        :description: Running tests and measuring coverage for PennyLane.
+        :description: Running tests.
         :link: guide/tests.html
+
+    .. raw:: html
+
+        </div>
+        <div class="row g-3 mt-1">
+
+    .. title-card::
+        :name: Documentation
+        :description: Building and contributing modules and packages to the PennyLane documentation.
+        :link: guide/documentation.html
+
+    .. title-card::
+        :name: Architecture Design Records
+        :description: Proposing important architectural decisions and tracking design rationale over time.
+        :link: guide/adr.html
+
+    .. title-card::
+        :name: Deprecations and Removals
+        :description: Ensuring safe migration paths when introducing breaking changes.
+        :link: guide/deprecations_removals.html
 
     .. raw:: html
 
@@ -271,13 +291,33 @@ Title Card
 
 .. title-card::
     :name: Contribution guide
-    :description: How to get involved in the PennyLane community.
+    :description: How to get involved in the PennyLane community and start contributing through issues, discussions, and pull requests.
     :link: guide/contributing.html
 
 .. title-card::
     :name: Software tests
-    :description: Running tests and measuring coverage for PennyLane.
+    :description: Running tests.
     :link: guide/tests.html
+
+.. raw:: html
+
+    </div>
+    <div class="row g-3 mt-1">
+
+.. title-card::
+    :name: Documentation
+    :description: Building and contributing modules and packages to the PennyLane documentation.
+    :link: guide/documentation.html
+
+.. title-card::
+    :name: Architecture Design Records
+    :description: Proposing important architectural decisions and tracking design rationale over time.
+    :link: guide/adr.html
+
+.. title-card::
+    :name: Deprecations and Removals
+    :description: Ensuring safe migration paths when introducing breaking changes.
+    :link: guide/deprecations_removals.html
 
 .. raw:: html
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,5 @@
 docutils==0.16  # Implicitly required by m2r2 v0.3.2
+setuptools>=45,<82  # setuptools 82+ removed pkg_resources, required by m2r2
 matplotlib==3.9.2
 m2r2==0.3.2
 pillow==11.0.0

--- a/xanadu_sphinx_theme/directives/community_card.py
+++ b/xanadu_sphinx_theme/directives/community_card.py
@@ -5,71 +5,37 @@ from inspect import cleandoc
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from docutils.statemachine import StringList
 
 COMMUNITY_CARD_TEMPLATE = cleandoc(
     """
-    .. raw:: html
-
-        <div class="card community-card plugin-card" id={id}>
-            <div class="card-header {colour}">
-                <h4 class="card-header__text">{title}</h4>
-            </div>
-            <div class="card-body">
-                <div class="row">
-                    <div class="col-lg-8 d-flex flex-column">
-                        <div>
-                            <h6>{author}</h6>
-                            <p class="plugin-card__meta">
-                                <i class="far fa-clock pe-1"></i> {date}
-                            </p>
-                        </div>
-                        <p class="plugin-card__description">
-                            {description}
+    <div class="card community-card plugin-card" id={id}>
+        <div class="card-header {colour}">
+            <h4 class="card-header__text">{title}</h4>
+        </div>
+        <div class="card-body">
+            <div class="row">
+                <div class="col-lg-8 d-flex flex-column">
+                    <div>
+                        <h6>{author}</h6>
+                        <p class="plugin-card__meta">
+                            <i class="far fa-clock pe-1"></i> {date}
                         </p>
-                        <div class="mt-auto plugin-card__read-more-wrapper">
-                            <a
-                              class="plugin-card__read-more text-primary d-none"
-                              data-bs-toggle="modal"
-                              data-bs-target="#{id}-modal"
-                            >
-                                Read More
-                            </a>
-                        </div>
                     </div>
-                    <div class="col-lg-4 d-flex">
-                        <div class="plugin-card__buttons">
-                            {paper_footer}
-                            {blog_footer}
-                            {code_footer}
-                        </div>
+                    <p class="plugin-card__description">
+                        {description}
+                    </p>
+                    <div class="mt-auto plugin-card__read-more-wrapper">
+                        <a
+                          class="plugin-card__read-more text-primary d-none"
+                          data-bs-toggle="modal"
+                          data-bs-target="#{id}-modal"
+                        >
+                            Read More
+                        </a>
                     </div>
                 </div>
-            </div>
-        </div>
-
-        <div
-          class="modal fade" id="{id}-modal"
-          tabindex="-1"
-          role="dialog"
-          aria-labelledby="{id}-modal"
-          aria-hidden="true"
-        >
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title mt-0">{title}</h5>
-                        <button
-                          type="button"
-                          class="btn-close"
-                          data-bs-dismiss="modal"
-                          aria-label="Close"
-                        ></button>
-                    </div>
-                    <div class="modal-body">
-                        {description}
-                    </div>
-                    <div class="modal-footer">
+                <div class="col-lg-4 d-flex">
+                    <div class="plugin-card__buttons">
                         {paper_footer}
                         {blog_footer}
                         {code_footer}
@@ -77,6 +43,37 @@ COMMUNITY_CARD_TEMPLATE = cleandoc(
                 </div>
             </div>
         </div>
+    </div>
+
+    <div
+      class="modal fade" id="{id}-modal"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="{id}-modal"
+      aria-hidden="true"
+    >
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title mt-0">{title}</h5>
+                    <button
+                      type="button"
+                      class="btn-close"
+                      data-bs-dismiss="modal"
+                      aria-label="Close"
+                    ></button>
+                </div>
+                <div class="modal-body">
+                    {description}
+                </div>
+                <div class="modal-footer">
+                    {paper_footer}
+                    {blog_footer}
+                    {code_footer}
+                </div>
+            </div>
+        </div>
+    </div>
     """
 )
 
@@ -153,7 +150,7 @@ class CommunityCardDirective(Directive):
         id_ += self.options["date"].split("/")[-1]
         id_ += self.options["title"].split(" ")[0].lower()
 
-        card_rst = COMMUNITY_CARD_TEMPLATE.format(
+        html = COMMUNITY_CARD_TEMPLATE.format(
             title=self.options["title"],
             author=self.options["author"],
             description=" ".join(description),
@@ -164,8 +161,4 @@ class CommunityCardDirective(Directive):
             colour=colour,
             id=id_,
         )
-
-        thumbnail = StringList(card_rst.split("\n"))
-        thumb = nodes.paragraph()
-        self.state.nested_parse(thumbnail, self.content_offset, thumb)
-        return [thumb]
+        return [nodes.raw(text=html, format="html")]

--- a/xanadu_sphinx_theme/directives/community_card.py
+++ b/xanadu_sphinx_theme/directives/community_card.py
@@ -9,69 +9,38 @@ from docutils.parsers.rst import Directive, directives
 COMMUNITY_CARD_TEMPLATE = cleandoc(
     """
     <div class="card community-card plugin-card" id={id}>
-        <div class="card-header {colour}">
+        <div class="card-header">
             <h4 class="card-header__text">{title}</h4>
+            <h6 class="plugin-card__author">{author}</h6>
+            <p class="plugin-card__meta">Added: {date}</p>
         </div>
         <div class="card-body">
-            <div class="row">
-                <div class="col-lg-8 d-flex flex-column">
-                    <div>
-                        <h6>{author}</h6>
-                        <p class="plugin-card__meta">
-                            <i class="far fa-clock pe-1"></i> {date}
-                        </p>
-                    </div>
-                    <p class="plugin-card__description">
+            <div class="plugin-card__description-section">
+                <div class="collapse plugin-card__description-collapse" id="{id}-description">
+                    <p class="plugin-card__description plugin-card__description--expanded">
                         {description}
                     </p>
-                    <div class="mt-auto plugin-card__read-more-wrapper">
-                        <a
-                          class="plugin-card__read-more text-primary d-none"
-                          data-bs-toggle="modal"
-                          data-bs-target="#{id}-modal"
-                        >
-                            Read More
-                        </a>
-                    </div>
                 </div>
-                <div class="col-lg-4 d-flex">
-                    <div class="plugin-card__buttons">
-                        {paper_footer}
-                        {blog_footer}
-                        {code_footer}
-                    </div>
-                </div>
+                <p class="plugin-card__description plugin-card__description--preview">
+                    {description}
+                </p>
+                <a
+                  class="plugin-card__read-more collapsed"
+                  data-bs-toggle="collapse"
+                  href="#{id}-description"
+                  role="button"
+                  aria-expanded="false"
+                  aria-controls="{id}-description"
+                >
+                    <span class="plugin-card__read-more-label-collapsed">Read more</span>
+                    <span class="plugin-card__read-more-label-expanded">Collapse</span>
+                </a>
             </div>
         </div>
-    </div>
-
-    <div
-      class="modal fade" id="{id}-modal"
-      tabindex="-1"
-      role="dialog"
-      aria-labelledby="{id}-modal"
-      aria-hidden="true"
-    >
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title mt-0">{title}</h5>
-                    <button
-                      type="button"
-                      class="btn-close"
-                      data-bs-dismiss="modal"
-                      aria-label="Close"
-                    ></button>
-                </div>
-                <div class="modal-body">
-                    {description}
-                </div>
-                <div class="modal-footer">
-                    {paper_footer}
-                    {blog_footer}
-                    {code_footer}
-                </div>
-            </div>
+        <div class="plugin-card__footer">
+            {paper_footer}
+            {blog_footer}
+            {code_footer}
         </div>
     </div>
     """
@@ -79,19 +48,19 @@ COMMUNITY_CARD_TEMPLATE = cleandoc(
 
 PAPER_FOOTER_TEMPLATE = cleandoc(
     """
-    <a href="{paper}" class="btn btn-info plugin-card__paper-btn" style="width: 100%;"><i class="fas fa-book"></i> Paper</a>
+    <a href="{paper}" class="btn plugin-card__action-btn plugin-card__paper-btn"><i class="bx bx-book"></i> View paper</a>
     """
 )
 
 BLOG_FOOTER_TEMPLATE = cleandoc(
     """
-    <a href="{blog}" class="btn btn-info plugin-card__blog-btn" style="width: 100%;"><i class="fas fa-newspaper"></i> Blog</a>
+    <a href="{blog}" class="btn plugin-card__action-btn plugin-card__blog-btn"><i class="bx bx-news"></i> Blog</a>
     """
 )
 
 CODE_FOOTER_TEMPLATE = cleandoc(
     """
-    <a href="{code}" class="btn btn-info plugin-card__code-btn" style="width: 100%;"><i class="fas fa-code-branch"></i></i> Code</a>
+    <a href="{code}" class="btn plugin-card__action-btn plugin-card__action-btn--outlined plugin-card__code-btn"><i class="bx bx-git-branch"></i> Code</a>
     """
 )
 
@@ -117,7 +86,6 @@ class CommunityCardDirective(Directive):
 
     def run(self):
         description = [i if i != "" else "<br><br>" for i in self.content]
-        colour = self.options.get("colour", "weird-blue-gradient")
 
         if "paper" in self.options:
             paper_footer = PAPER_FOOTER_TEMPLATE.format(paper=self.options["paper"])
@@ -158,7 +126,6 @@ class CommunityCardDirective(Directive):
             paper_footer=paper_footer,
             code_footer=code_footer,
             blog_footer=blog_footer,
-            colour=colour,
             id=id_,
         )
         return [nodes.raw(text=html, format="html")]

--- a/xanadu_sphinx_theme/directives/community_card.py
+++ b/xanadu_sphinx_theme/directives/community_card.py
@@ -64,9 +64,7 @@ COMMUNITY_CARD_TEMPLATE = cleandoc(
                           class="btn-close"
                           data-bs-dismiss="modal"
                           aria-label="Close"
-                        >
-                            <span class="visually-hidden">Close</span>
-                        </button>
+                        ></button>
                     </div>
                     <div class="modal-body">
                         {description}
@@ -96,7 +94,7 @@ BLOG_FOOTER_TEMPLATE = cleandoc(
 
 CODE_FOOTER_TEMPLATE = cleandoc(
     """
-    <a href="{code}" class="btn btn-secondary plugin-card__code-btn" style="width: 100%;"><i class="fas fa-code-branch"></i></i> Code</a>
+    <a href="{code}" class="btn btn-info plugin-card__code-btn" style="width: 100%;"><i class="fas fa-code-branch"></i></i> Code</a>
     """
 )
 

--- a/xanadu_sphinx_theme/directives/community_card.py
+++ b/xanadu_sphinx_theme/directives/community_card.py
@@ -12,7 +12,7 @@ COMMUNITY_CARD_TEMPLATE = cleandoc(
     .. raw:: html
 
         <div class="card community-card plugin-card" id={id}>
-            <div class="card-header {colour} lighten-4">
+            <div class="card-header {colour}">
                 <h4 class="card-header__text">{title}</h4>
             </div>
             <div class="card-body">
@@ -20,8 +20,8 @@ COMMUNITY_CARD_TEMPLATE = cleandoc(
                     <div class="col-lg-8 d-flex flex-column">
                         <div>
                             <h6>{author}</h6>
-                            <p class="font-small">
-                                <i class="far fa-clock pr-1"></i> {date}
+                            <p class="plugin-card__meta">
+                                <i class="far fa-clock pe-1"></i> {date}
                             </p>
                         </div>
                         <p class="plugin-card__description">
@@ -30,8 +30,8 @@ COMMUNITY_CARD_TEMPLATE = cleandoc(
                         <div class="mt-auto plugin-card__read-more-wrapper">
                             <a
                               class="plugin-card__read-more text-primary d-none"
-                              data-toggle="modal"
-                              data-target="#{id}-modal"
+                              data-bs-toggle="modal"
+                              data-bs-target="#{id}-modal"
                             >
                                 Read More
                             </a>
@@ -61,11 +61,11 @@ COMMUNITY_CARD_TEMPLATE = cleandoc(
                         <h5 class="modal-title mt-0">{title}</h5>
                         <button
                           type="button"
-                          class="close"
-                          data-dismiss="modal"
+                          class="btn-close"
+                          data-bs-dismiss="modal"
                           aria-label="Close"
                         >
-                            <span aria-hidden="true">&times;</span>
+                            <span class="visually-hidden">Close</span>
                         </button>
                     </div>
                     <div class="modal-body">
@@ -96,7 +96,7 @@ BLOG_FOOTER_TEMPLATE = cleandoc(
 
 CODE_FOOTER_TEMPLATE = cleandoc(
     """
-    <a href="{code}" class="btn btn-default plugin-card__code-btn" style="width: 100%;"><i class="fas fa-code-branch"></i></i> Code</a>
+    <a href="{code}" class="btn btn-secondary plugin-card__code-btn" style="width: 100%;"><i class="fas fa-code-branch"></i></i> Code</a>
     """
 )
 
@@ -122,7 +122,7 @@ class CommunityCardDirective(Directive):
 
     def run(self):
         description = [i if i != "" else "<br><br>" for i in self.content]
-        colour = self.options.get("colour", "heavy-rain-gradient")
+        colour = self.options.get("colour", "weird-blue-gradient")
 
         if "paper" in self.options:
             paper_footer = PAPER_FOOTER_TEMPLATE.format(paper=self.options["paper"])

--- a/xanadu_sphinx_theme/directives/details.py
+++ b/xanadu_sphinx_theme/directives/details.py
@@ -17,9 +17,8 @@ TEMPLATE = cleandoc(
           aria-expanded="false"
           aria-controls="details"
         >
-            <h2 style="font-size: 24px;">
-                <i class="fas fa-angle-down rotate" style="float: right;"></i> {title}
-            </h2>
+            <h2>{title}</h2>
+            <i class="bx bx-chevron-down rotate"></i>
         </a>
         <div class="collapse" id="{href}">
 

--- a/xanadu_sphinx_theme/directives/details.py
+++ b/xanadu_sphinx_theme/directives/details.py
@@ -12,7 +12,7 @@ TEMPLATE = cleandoc(
 
         <a
           class="details-header collapse-header"
-          data-toggle="collapse"
+          data-bs-toggle="collapse"
           href="#{href}"
           aria-expanded="false"
           aria-controls="details"

--- a/xanadu_sphinx_theme/directives/gallery_item.py
+++ b/xanadu_sphinx_theme/directives/gallery_item.py
@@ -45,21 +45,14 @@ from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
 from sphinx_gallery.gen_rst import scale_image
 
-TEMPLATE = cleandoc(
+OPEN_TEMPLATE = '<div class="gallery-item-thumbcontainer col-auto" {attributes}>'
+CLOSE_TEMPLATE = "</div>"
+
+FIGURE_TEMPLATE = cleandoc(
     """
-    .. raw:: html
+    .. figure:: {thumbnail}
 
-        <div class="gallery-item-thumbcontainer col-auto" {attributes}>
-
-    .. only:: html
-
-        .. figure:: {thumbnail}
-
-            {description}
-
-    .. raw:: html
-
-        </div>
+        {description}
     """
 )
 
@@ -120,12 +113,14 @@ class GalleryItemDirective(Directive):
         attributes_list = [f"{k}='{v}'" for k, v in attributes_dict.items()]
         attributes_html = " ".join(attributes_list)
 
-        thumbnail_rst = TEMPLATE.format(
+        figure_rst = FIGURE_TEMPLATE.format(
             description=self.options["description"],
             thumbnail=thumbnail,
-            attributes=attributes_html,
         )
-        thumbnail = StringList(thumbnail_rst.split("\n"))
-        thumb = nodes.paragraph()
-        self.state.nested_parse(thumbnail, self.content_offset, thumb)
-        return [thumb]
+        figure_list = StringList(figure_rst.split("\n"))
+        figure_node = nodes.container()
+        self.state.nested_parse(figure_list, self.content_offset, figure_node)
+
+        open_div = nodes.raw(text=OPEN_TEMPLATE.format(attributes=attributes_html), format="html")
+        close_div = nodes.raw(text=CLOSE_TEMPLATE, format="html")
+        return [open_div, *figure_node.children, close_div]

--- a/xanadu_sphinx_theme/directives/gallery_item.py
+++ b/xanadu_sphinx_theme/directives/gallery_item.py
@@ -49,7 +49,7 @@ TEMPLATE = cleandoc(
     """
     .. raw:: html
 
-        <div class="gallery-item-thumbcontainer" {attributes}>
+        <div class="gallery-item-thumbcontainer col-auto" {attributes}>
 
     .. only:: html
 

--- a/xanadu_sphinx_theme/directives/index_card.py
+++ b/xanadu_sphinx_theme/directives/index_card.py
@@ -7,25 +7,23 @@ from docutils.parsers.rst import Directive, directives
 
 TEMPLATE = cleandoc(
     """
-    .. raw:: html
-
-        <div class="col-lg-4 mb-2 d-flex align-items-stretch">
-            <a class="index-card-link d-flex w-100" href="{link}">
-                <div class="card rounded-3 h-100 w-100">
-                    <div class="d-flex">
-                        <div>
-                            <h3 class="card-title ps-3 mt-4">
-                                {name}
-                            </h3>
-                            <p class="mb-3 text-muted px-3">
-                                {description}
-                                <i class="fas fa-angle-double-right"></i>
-                            </p>
-                        </div>
+    <div class="col-lg-4 mb-2 d-flex align-items-stretch">
+        <a class="index-card-link d-flex w-100" href="{link}">
+            <div class="card rounded-3 h-100 w-100">
+                <div class="d-flex">
+                    <div>
+                        <h3 class="card-title ps-3 mt-4">
+                            {name}
+                        </h3>
+                        <p class="mb-3 text-muted px-3">
+                            {description}
+                            <i class="fas fa-angle-double-right"></i>
+                        </p>
                     </div>
                 </div>
-            </a>
-        </div>
+            </div>
+        </a>
+    </div>
     """
 )
 

--- a/xanadu_sphinx_theme/directives/index_card.py
+++ b/xanadu_sphinx_theme/directives/index_card.py
@@ -9,17 +9,15 @@ TEMPLATE = cleandoc(
     """
     <div class="col-lg-4 mb-2 d-flex align-items-stretch">
         <a class="index-card-link d-flex w-100" href="{link}">
-            <div class="card rounded-3 h-100 w-100">
-                <div class="d-flex">
-                    <div>
-                        <h3 class="card-title ps-3 mt-4">
-                            {name}
-                        </h3>
-                        <p class="mb-3 text-muted px-3">
-                            {description}
-                            <i class="fas fa-angle-double-right"></i>
-                        </p>
-                    </div>
+            <div class="card index-card h-100 w-100">
+                <div class="card-header index-card-header">
+                    <h3 class="index-card-title">{name}</h3>
+                </div>
+                <div class="card-body index-card-body">
+                    <p class="card-text index-card-description">
+                        {description}
+                        <i class="fas fa-angle-double-right"></i>
+                    </p>
                 </div>
             </div>
         </a>

--- a/xanadu_sphinx_theme/directives/index_card.py
+++ b/xanadu_sphinx_theme/directives/index_card.py
@@ -4,21 +4,20 @@ from inspect import cleandoc
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from docutils.statemachine import StringList
 
 TEMPLATE = cleandoc(
     """
     .. raw:: html
 
-        <div class="col-lg-4 mb-2 align-items-stretch">
-            <a href="{link}">
-                <div class="card rounded-lg" style="height:100%;">
+        <div class="col-lg-4 mb-2 d-flex align-items-stretch">
+            <a class="index-card-link d-flex w-100" href="{link}">
+                <div class="card rounded-3 h-100 w-100">
                     <div class="d-flex">
                         <div>
-                            <h3 class="card-title pl-3 mt-4">
+                            <h3 class="card-title ps-3 mt-4">
                                 {name}
                             </h3>
-                            <p class="mb-3 grey-text px-3">
+                            <p class="mb-3 text-muted px-3">
                                 {description}
                                 <i class="fas fa-angle-double-right"></i>
                             </p>
@@ -51,9 +50,5 @@ class IndexCardDirective(Directive):
         link = self.options["link"]
         desc = self.options["description"]
 
-        thumbnail_rst = TEMPLATE.format(name=name, link=link, description=desc)
-        thumbnail = StringList(thumbnail_rst.split("\n"))
-
-        thumb = nodes.paragraph()
-        self.state.nested_parse(thumbnail, self.content_offset, thumb)
-        return [thumb]
+        html = TEMPLATE.format(name=name, link=link, description=desc)
+        return [nodes.raw(text=html, format="html")]

--- a/xanadu_sphinx_theme/directives/related_demo.py
+++ b/xanadu_sphinx_theme/directives/related_demo.py
@@ -4,16 +4,13 @@ from inspect import cleandoc
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
-from docutils.statemachine import StringList
 
 TEMPLATE = cleandoc(
     """
-    .. raw:: html
-
-        <script type="text/javascript">
-            var related_tutorials = [{urls}];
-            var related_tutorials_titles = {link_text};
-        </script>
+    <script type="text/javascript">
+        var related_tutorials = [{urls}];
+        var related_tutorials_titles = {link_text};
+    </script>
     """
 )
 
@@ -32,7 +29,4 @@ class RelatedDemoDirective(Directive):
         link_text = [" ".join(u.split(" ")[1:]) for u in list(self.content)]
         urls = ", ".join(urls)
         html = TEMPLATE.format(urls=urls, link_text=link_text)
-        str_list = StringList(html.split("\n"))
-        related_variables = nodes.paragraph()
-        self.state.nested_parse(str_list, self.content_offset, related_variables)
-        return [related_variables]
+        return [nodes.raw(text=html, format="html")]

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -7,7 +7,7 @@ from docutils.parsers.rst import Directive, directives
 
 TEMPLATE = cleandoc(
     """
-    <div class="title-card-col col-lg-4 mb-2">
+    <div class="title-card-col col-lg-4">
         <a class="title-card-link d-flex w-100" href="{link}">
             <div class="card title-card h-100 w-100">
                 <div class="card-header title-card-header">

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -7,13 +7,15 @@ from docutils.parsers.rst import Directive, directives
 
 TEMPLATE = cleandoc(
     """
-    <div class="card title-card" style="width: 15rem; float:left; margin: 10px;">
-        <a class="title-card-link" href={link}>
-            <div class="card-header title-card-header">
-                <span class="title-card-title">{name}</span>
-            </div>
-            <div class="card-body title-card-body">
-                <p class="card-text title-card-description">{description}</p>
+    <div class="col-lg-4 mb-2 d-flex align-items-stretch">
+        <a class="title-card-link d-flex w-100" href="{link}">
+            <div class="card title-card h-100 w-100">
+                <div class="card-header title-card-header">
+                    <span class="title-card-title">{name}</span>
+                </div>
+                <div class="card-body title-card-body">
+                    <p class="card-text title-card-description">{description}</p>
+                </div>
             </div>
         </a>
     </div>

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -11,7 +11,7 @@ TEMPLATE = cleandoc(
     .. raw:: html
 
         <div class="card" style="width: 15rem; float:left; margin: 10px;">
-            <a href={link}>
+            <a class="title-card-link" href={link}>
                 <div class="card-header">
                     <b>{name}</b>
                 </div>

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -7,7 +7,7 @@ from docutils.parsers.rst import Directive, directives
 
 TEMPLATE = cleandoc(
     """
-    <div class="col-lg-4 mb-2 d-flex align-items-stretch">
+    <div class="title-card-col col-lg-4 mb-2 d-flex align-items-stretch">
         <a class="title-card-link d-flex w-100" href="{link}">
             <div class="card title-card h-100 w-100">
                 <div class="card-header title-card-header">

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -4,22 +4,19 @@ from inspect import cleandoc
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from docutils.statemachine import StringList
 
 TEMPLATE = cleandoc(
     """
-    .. raw:: html
-
-        <div class="card" style="width: 15rem; float:left; margin: 10px;">
-            <a class="title-card-link" href={link}>
-                <div class="card-header">
-                    <b>{name}</b>
-                </div>
-                <div class="card-body">
-                    <p class="card-text"> {description} </p>
-                </div>
-            </a>
-        </div>
+    <div class="card" style="width: 15rem; float:left; margin: 10px;">
+        <a class="title-card-link" href={link}>
+            <div class="card-header">
+                <b>{name}</b>
+            </div>
+            <div class="card-body">
+                <p class="card-text"> {description} </p>
+            </div>
+        </a>
+    </div>
     """
 )
 
@@ -44,9 +41,5 @@ class TitleCardDirective(Directive):
         link = self.options["link"]
         desc = self.options["description"]
 
-        thumbnail_rst = TEMPLATE.format(name=name, link=link, description=desc)
-        thumbnail = StringList(thumbnail_rst.split("\n"))
-
-        thumb = nodes.paragraph()
-        self.state.nested_parse(thumbnail, self.content_offset, thumb)
-        return [thumb]
+        html = TEMPLATE.format(name=name, link=link, description=desc)
+        return [nodes.raw(text=html, format="html")]

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -7,7 +7,7 @@ from docutils.parsers.rst import Directive, directives
 
 TEMPLATE = cleandoc(
     """
-    <div class="title-card-col col-lg-4 mb-2 d-flex align-items-stretch">
+    <div class="title-card-col col-lg-4 mb-2">
         <a class="title-card-link d-flex w-100" href="{link}">
             <div class="card title-card h-100 w-100">
                 <div class="card-header title-card-header">

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -7,13 +7,13 @@ from docutils.parsers.rst import Directive, directives
 
 TEMPLATE = cleandoc(
     """
-    <div class="card" style="width: 15rem; float:left; margin: 10px;">
+    <div class="card title-card" style="width: 15rem; float:left; margin: 10px;">
         <a class="title-card-link" href={link}>
-            <div class="card-header">
-                <b>{name}</b>
+            <div class="card-header title-card-header">
+                <span class="title-card-title">{name}</span>
             </div>
-            <div class="card-body">
-                <p class="card-text"> {description} </p>
+            <div class="card-body title-card-body">
+                <p class="card-text title-card-description">{description}</p>
             </div>
         </a>
     </div>

--- a/xanadu_sphinx_theme/directives/youtube_video.py
+++ b/xanadu_sphinx_theme/directives/youtube_video.py
@@ -10,20 +10,23 @@ TEMPLATE = cleandoc(
     <div class="col-lg-6 col-md-6 col-12">
         <a class="youtube-video-link" href="https://youtube.com/watch?v={id}" target="_blank">
             <div class="card video-card">
-                <img
-                  class="card-img-top img-fluid"
-                  src="https://img.youtube.com/vi/{id}/hqdefault.jpg"
-                />
+                <div class="video-card__media">
+                    <img
+                      class="card-img-top img-fluid"
+                      src="https://img.youtube.com/vi/{id}/hqdefault.jpg"
+                      alt="{title}"
+                    />
+                </div>
                 <div class="card-body">
                     <h4 class="card-title">{title}</h4>
-                    <p class="card-text grey-text">{author}</p>
-                    <p class="card-text">
+                    <p class="card-text video-card__author">{author}</p>
+                    <p class="card-text video-card__description">
                         {description}
                     </p>
                 </div>
-                <div class="white-text watch">
-                    <hr>
-                    <h5>Watch <i class="fas fa-angle-double-right"></i></h5>
+                <div class="video-card__footer">
+                    <span class="video-card__watch-label">Watch</span>
+                    <i class="bx bx-chevron-right video-card__watch-icon"></i>
                 </div>
             </div>
         </a>

--- a/xanadu_sphinx_theme/directives/youtube_video.py
+++ b/xanadu_sphinx_theme/directives/youtube_video.py
@@ -8,7 +8,7 @@ from docutils.parsers.rst import Directive, directives
 TEMPLATE = cleandoc(
     """
     <div class="col-lg-6 col-md-6 col-12">
-        <a class="youtube-video-link" href="https://youtube.com/watch?v={id}" target="_blank">
+        <a class="youtube-video-link" href="https://youtube.com/watch?v={id}" target="_blank" rel="noopener noreferrer">
             <div class="card video-card">
                 <div class="video-card__media">
                     <img

--- a/xanadu_sphinx_theme/directives/youtube_video.py
+++ b/xanadu_sphinx_theme/directives/youtube_video.py
@@ -4,13 +4,11 @@ from inspect import cleandoc
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from docutils.statemachine import StringList
 
 TEMPLATE = cleandoc(
     """
-    .. raw:: html
-
-        <a href="https://youtube.com/watch?v={id}" target="_blank">
+    <div class="col-lg-6 col-md-6 col-12">
+        <a class="youtube-video-link" href="https://youtube.com/watch?v={id}" target="_blank">
             <div class="card video-card">
                 <img
                   class="card-img-top img-fluid"
@@ -29,6 +27,7 @@ TEMPLATE = cleandoc(
                 </div>
             </div>
         </a>
+    </div>
     """
 )
 
@@ -51,13 +50,10 @@ class YouTubeVideoDirective(Directive):
         ytid = self.arguments[0]
         description = [i if i != "" else "<br><br>" for i in self.content]
 
-        thumbnail_rst = TEMPLATE.format(
+        html = TEMPLATE.format(
             id=ytid,
             title=self.options["title"],
             author=self.options["author"],
             description=" ".join(description),
         )
-        thumbnail = StringList(thumbnail_rst.split("\n"))
-        thumb = nodes.paragraph()
-        self.state.nested_parse(thumbnail, self.content_offset, thumb)
-        return [thumb]
+        return [nodes.raw(text=html, format="html")]

--- a/xanadu_sphinx_theme/footer.html
+++ b/xanadu_sphinx_theme/footer.html
@@ -54,9 +54,9 @@
       {%- if show_copyright %}
         <p class="footer-copyright-item">
           {%- if hasdoc('copyright') %}
-            {% trans path=pathto('copyright'), copyright=copyright|e %}<a href="{{ path }}">Copyright</a> &copy; {{ copyright }}{% endtrans %}
+            {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}{% endtrans %}
           {%- else %}
-            {% trans copyright=copyright|e %}Copyright &copy; {{ copyright }}{% endtrans %}
+            {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}{% endtrans %}
           {%- endif %}
         </p>
       {%- endif %}

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -329,7 +329,7 @@
     });
   </script>
   <!-- Overlay Scrollbars -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.browser.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.browser.es6.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Syntax Highlighting -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
   <script type="text/javascript">hljs.initHighlightingOnLoad();</script>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -26,7 +26,7 @@
   <!-- Bootstrap core CSS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <!-- Overlay Scrollbars -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/overlayscrollbars@2.11.4/styles/overlayscrollbars.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/styles/overlayscrollbars.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <!-- Syntax Highlighting -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/tomorrow-night.min.css">
 
@@ -329,7 +329,7 @@
     });
   </script>
   <!-- Overlay Scrollbars -->
-  <script src="https://cdn.jsdelivr.net/npm/overlayscrollbars@2.11.4/browser/overlayscrollbars.browser.es6.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.cjs.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Syntax Highlighting -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
   <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
@@ -355,11 +355,7 @@
     document.querySelectorAll("h1 ~ .section").forEach((element) => {
       element.classList.remove("section");
     });
-    const overlayScrollbarsApi = window.OverlayScrollbarsGlobal && window.OverlayScrollbarsGlobal.OverlayScrollbars;
-    const nanoContainer = document.querySelector(".nano");
-    if (typeof overlayScrollbarsApi === "function" && nanoContainer) {
-      overlayScrollbarsApi(nanoContainer, {});
-    }
+    OverlayScrollbars(document.querySelector('.nano'), {});
   </script>
 
   <script type="text/javascript">
@@ -406,10 +402,7 @@
             nanoElement.scrollTop = currentElement.offsetTop - nanoElement.offsetTop;
           }
       } else {
-          const nanoElement = document.querySelector(".nano");
-          if (nanoElement) {
-            nanoElement.scrollTop = 0;
-          }
+          document.querySelector(".nano").scrollTop = 0;
       }
     }
     document.addEventListener('DOMContentLoaded', function () {

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -26,7 +26,7 @@
   <!-- Bootstrap core CSS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <!-- Overlay Scrollbars -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/styles/overlayscrollbars.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/overlayscrollbars@2.11.4/styles/overlayscrollbars.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <!-- Syntax Highlighting -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/styles/tomorrow-night.min.css">
 
@@ -329,7 +329,7 @@
     });
   </script>
   <!-- Overlay Scrollbars -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.browser.es6.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/overlayscrollbars@2.11.4/browser/overlayscrollbars.browser.es6.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Syntax Highlighting -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
   <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
@@ -355,8 +355,10 @@
     document.querySelectorAll("h1 ~ .section").forEach((element) => {
       element.classList.remove("section");
     });
-    if (window.OverlayScrollbarsGlobal && typeof window.OverlayScrollbarsGlobal.OverlayScrollbars === "function") {
-      window.OverlayScrollbarsGlobal.OverlayScrollbars(document.querySelector('.nano'), {});
+    const overlayScrollbarsApi = window.OverlayScrollbarsGlobal && window.OverlayScrollbarsGlobal.OverlayScrollbars;
+    const nanoContainer = document.querySelector(".nano");
+    if (typeof overlayScrollbarsApi === "function" && nanoContainer) {
+      overlayScrollbarsApi(nanoContainer, {});
     }
   </script>
 
@@ -404,7 +406,10 @@
             nanoElement.scrollTop = currentElement.offsetTop - nanoElement.offsetTop;
           }
       } else {
-          document.querySelector(".nano").scrollTop = 0;
+          const nanoElement = document.querySelector(".nano");
+          if (nanoElement) {
+            nanoElement.scrollTop = 0;
+          }
       }
     }
     document.addEventListener('DOMContentLoaded', function () {

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -16,7 +16,7 @@
 
   <!-- Google Fonts -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500&display=swap">
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css">

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -329,7 +329,7 @@
     });
   </script>
   <!-- Overlay Scrollbars -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.cjs.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.browser.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Syntax Highlighting -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
   <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
@@ -355,7 +355,9 @@
     document.querySelectorAll("h1 ~ .section").forEach((element) => {
       element.classList.remove("section");
     });
-    OverlayScrollbars(document.querySelector('.nano'), {});
+    if (window.OverlayScrollbarsGlobal && typeof window.OverlayScrollbarsGlobal.OverlayScrollbars === "function") {
+      window.OverlayScrollbarsGlobal.OverlayScrollbars(document.querySelector('.nano'), {});
+    }
   </script>
 
   <script type="text/javascript">

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -24,9 +24,7 @@
   <link href="https://cdn.boxicons.com/fonts/basic/boxicons.min.css" rel="stylesheet">
   <link href="https://cdn.boxicons.com/fonts/brands/boxicons-brands.min.css" rel="stylesheet">
   <!-- Bootstrap core CSS -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap.min.css">
-  <!-- Material Design Bootstrap -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.5.14/css/mdb.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <!-- Overlay Scrollbars -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/styles/overlayscrollbars.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <!-- Syntax Highlighting -->
@@ -262,9 +260,7 @@
   <!-- MathJax -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <!-- Bootstrap core JavaScript -->
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.3.1/js/bootstrap.min.js"></script>
-  <!-- MDB core JavaScript -->
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.8.10/js/mdb.min.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
   <!-- Overlay Scrollbars -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.cjs.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Syntax Highlighting -->

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -261,6 +261,73 @@
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <!-- Bootstrap core JavaScript -->
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script type="text/javascript">
+    // Bootstrap 4 -> 5 compatibility for downstream docs overrides.
+    document.addEventListener("DOMContentLoaded", () => {
+      document.querySelectorAll("[data-toggle]").forEach((element) => {
+        const toggleValue = element.getAttribute("data-toggle");
+        if (toggleValue !== null) {
+          element.setAttribute("data-bs-toggle", toggleValue);
+        }
+      });
+
+      document.querySelectorAll("[data-target]").forEach((element) => {
+        const targetValue = element.getAttribute("data-target");
+        if (targetValue !== null) {
+          element.setAttribute("data-bs-target", targetValue);
+        }
+      });
+
+      document.querySelectorAll("[data-dismiss]").forEach((element) => {
+        const dismissValue = element.getAttribute("data-dismiss");
+        if (dismissValue !== null) {
+          element.setAttribute("data-bs-dismiss", dismissValue);
+        }
+      });
+
+      // Keep old data-parent accordion semantics working in Bootstrap 5.
+      document.querySelectorAll(".collapse-header[data-bs-toggle='collapse']").forEach((header) => {
+        const parentSelector = header.getAttribute("data-parent");
+        if (!parentSelector) {
+          return;
+        }
+        const targetSelector = header.getAttribute("data-bs-target") || header.getAttribute("href");
+        if (!targetSelector || !targetSelector.startsWith("#")) {
+          return;
+        }
+        const collapseTarget = document.querySelector(targetSelector);
+        if (collapseTarget && !collapseTarget.hasAttribute("data-bs-parent")) {
+          collapseTarget.setAttribute("data-bs-parent", parentSelector);
+        }
+      });
+
+      // Upgrade legacy Font Awesome chevrons to Boxicons for consistency.
+      document.querySelectorAll(".collapse-header i.fa-angle-down, .collapse-header i.fas.fa-angle-down").forEach((icon) => {
+        icon.classList.remove("fa", "fas", "fa-angle-down");
+        icon.classList.add("bx", "bx-chevron-down");
+        icon.style.float = "";
+      });
+
+      // Keep icon orientation in sync with collapse state for all header variants.
+      document.querySelectorAll(".collapse-header").forEach((header) => {
+        const icon = header.querySelector("i.rotate");
+        const targetSelector = header.getAttribute("data-bs-target") || header.getAttribute("href");
+        if (icon === null || !targetSelector || !targetSelector.startsWith("#")) {
+          return;
+        }
+        const collapseTarget = document.querySelector(targetSelector);
+        if (!collapseTarget) {
+          return;
+        }
+
+        if (collapseTarget.classList.contains("show")) {
+          icon.classList.add("up");
+        }
+        collapseTarget.addEventListener("show.bs.collapse", () => icon.classList.add("up"));
+        collapseTarget.addEventListener("hide.bs.collapse", () => icon.classList.remove("up"));
+      });
+    });
+  </script>
   <!-- Overlay Scrollbars -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.cjs.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Syntax Highlighting -->

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -247,14 +247,18 @@
 
 {%- block footer %}
   <script type="text/javascript">
-    $("#mobile-toggle").click(function () {
-      $("#left-column").slideToggle("slow");
+    document.addEventListener("DOMContentLoaded", () => {
+      const mobileToggle = document.querySelector("#mobile-toggle");
+      const leftColumn = document.querySelector("#left-column");
+      if (mobileToggle !== null && leftColumn !== null) {
+        mobileToggle.addEventListener("click", () => {
+          const hidden = window.getComputedStyle(leftColumn).display === "none";
+          leftColumn.style.display = hidden ? "block" : "none";
+        });
+      }
     });
   </script>
 
-  <!-- jQuery -->
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
   <!-- MathJax -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <!-- Bootstrap core JavaScript -->
@@ -268,20 +272,26 @@
   <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
 
   <script type="text/javascript">
+    document.querySelectorAll("a.reference.internal").forEach((anchor) => {
+      const link = anchor.getAttribute("href");
+      if (!link) {
+        return;
+      }
 
-    $("a.reference.internal").each(function(){
-      var link = $(this).attr("href");
-
-      var hash = link.split("#")[1];
-      var page = link.split("#")[0].split("/").slice(-1)[0].replace(".html", "");
+      const hash = link.split("#")[1];
+      const page = link.split("#")[0].split("/").slice(-1)[0].replace(".html", "");
 
       if (hash == page) {
-        $(this).attr("href", link.split("#")[0]);
+        anchor.setAttribute("href", link.split("#")[0]);
       }
     });
 
-    $(".document > .section").removeClass("section");
-    $("h1 ~ .section").removeClass("section");
+    document.querySelectorAll(".document > .section").forEach((element) => {
+      element.classList.remove("section");
+    });
+    document.querySelectorAll("h1 ~ .section").forEach((element) => {
+      element.classList.remove("section");
+    });
     OverlayScrollbars(document.querySelector('.nano'), {});
   </script>
 
@@ -349,25 +359,69 @@
   </script>
 
     <script type="text/javascript">
-    var downloadNote = $(".sphx-glr-download-link-note.admonition.note");
-    if (downloadNote.length >= 1) {
-      var tutorialUrlArray = $("#tutorial-type").text().split('/');
-
-      if (tutorialUrlArray[0] == "demos") {
-        tutorialUrlArray[0] = "demonstrations";
+    function wrapElementWithLink(selector, attrs) {
+      const target = document.querySelector(selector);
+      if (target === null || target.parentElement === null || target.closest("a") !== null) {
+        return;
       }
 
-      var githubLink = "https://github.com/" + "{{ theme_github_repo }}" + "/blob/master/" + tutorialUrlArray.join("/") + ".py",
-          pythonLink = $(".sphx-glr-download .reference.download")[0].href,
-          notebookLink = $(".sphx-glr-download .reference.download")[1].href;
+      const anchor = document.createElement("a");
+      Object.entries(attrs).forEach(([key, value]) => {
+        anchor.setAttribute(key, value);
+      });
+      target.parentElement.insertBefore(anchor, target);
+      anchor.appendChild(target);
+    }
 
-      $(".download-python-link").wrap("<a href=" + pythonLink + " data-behavior='call-to-action-event' data-response='Download Python script' download target='_blank'/>");
-      $(".download-notebook-link").wrap("<a href=" + notebookLink + " data-behavior='call-to-action-event' data-response='Download Notebook' download target='_blank'/>");
-      $(".github-view-link").wrap("<a href=" + githubLink + " data-behavior='call-to-action-event' data-response='View on Github' target='_blank'/>");
-      $("#right-column").addClass("page-shadow");
+    var downloadNote = document.querySelectorAll(".sphx-glr-download-link-note.admonition.note");
+    if (downloadNote.length >= 1) {
+      const tutorialType = document.querySelector("#tutorial-type");
+      const downloadLinks = document.querySelectorAll(".sphx-glr-download .reference.download");
+      if (tutorialType !== null && downloadLinks.length >= 2) {
+        var tutorialUrlArray = tutorialType.textContent.split('/');
+
+        if (tutorialUrlArray[0] == "demos") {
+          tutorialUrlArray[0] = "demonstrations";
+        }
+
+        var githubLink = "https://github.com/" + "{{ theme_github_repo }}" + "/blob/master/" + tutorialUrlArray.join("/") + ".py",
+            pythonLink = downloadLinks[0].href,
+            notebookLink = downloadLinks[1].href;
+
+        wrapElementWithLink(".download-python-link", {
+          href: pythonLink,
+          "data-behavior": "call-to-action-event",
+          "data-response": "Download Python script",
+          download: "",
+          target: "_blank"
+        });
+        wrapElementWithLink(".download-notebook-link", {
+          href: notebookLink,
+          "data-behavior": "call-to-action-event",
+          "data-response": "Download Notebook",
+          download: "",
+          target: "_blank"
+        });
+        wrapElementWithLink(".github-view-link", {
+          href: githubLink,
+          "data-behavior": "call-to-action-event",
+          "data-response": "View on Github",
+          target: "_blank"
+        });
+
+        const rightColumn = document.querySelector("#right-column");
+        if (rightColumn !== null) {
+          rightColumn.classList.add("page-shadow");
+        }
+      }
     } else {
-      $(".xanadu-call-to-action-links").hide();
-      $("#bottom-dl").attr('style','display: none !important');
+      document.querySelectorAll(".xanadu-call-to-action-links").forEach((element) => {
+        element.style.display = "none";
+      });
+      const bottomDl = document.querySelector("#bottom-dl");
+      if (bottomDl !== null) {
+        bottomDl.style.setProperty("display", "none", "important");
+      }
     }
     </script>
 
@@ -388,12 +442,20 @@
       }
 
       if (typeof related_tutorials !== 'undefined') {
-          document.getElementById('related-tutorials').appendChild(makeUL(related_tutorials, related_tutorials_titles));
-          $("#related-tutorials ul li a").append(' <i class="fas fa-angle-double-right" style="font-size: smaller;"></i>')
-          $("#related-tutorials").show();
+          const relatedTutorials = document.querySelector("#related-tutorials");
+          if (relatedTutorials !== null) {
+            relatedTutorials.appendChild(makeUL(related_tutorials, related_tutorials_titles));
+            document.querySelectorAll("#related-tutorials ul li a").forEach((anchor) => {
+              anchor.insertAdjacentHTML("beforeend", ' <i class="fas fa-angle-double-right" style="font-size: smaller;"></i>');
+            });
+            relatedTutorials.style.display = "block";
+          }
 
     } else {
-          $("#related-tutorials").hide();
+          const relatedTutorials = document.querySelector("#related-tutorials");
+          if (relatedTutorials !== null) {
+            relatedTutorials.style.display = "none";
+          }
     }
     </script>
 
@@ -423,7 +485,7 @@
       }
     }
 
-    $(document).ready(() => {
+    document.addEventListener("DOMContentLoaded", () => {
       scrollToFragment(window.location.hash);
       window.addEventListener("popstate", (_) => scrollToFragment(document.location.hash), false);
     });
@@ -431,7 +493,7 @@
 
   <!-- Hide the rendering of :orphan: metadata. -->
   <script type="text/javascript">
-    $(document).ready(() => {
+    document.addEventListener("DOMContentLoaded", () => {
       const elements = document.getElementsByClassName("field-odd");
       for (const element of elements) {
           if (element.innerHTML.trim() === "orphan") {
@@ -635,10 +697,6 @@
         }
       }
     });
-  </script>
-
-  <script type="text/javascript">
-    jQuery.noConflict(true);
   </script>
 
   {% include "footer.html" %}

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3602,7 +3602,6 @@ pre {
 /* When title cards are already inside a `.row`, defer to Bootstrap grid. */
 .row > .title-card-col {
   display: flex;
-  width: auto;
   padding-right: 0;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3436,18 +3436,24 @@ pre {
   padding: 12px 12px 0 12px;
 }
 
-.gallery-item-thumbcontainer p.caption {
+.gallery-item-thumbcontainer p.caption,
+.gallery-item-thumbcontainer figure figcaption,
+.gallery-item-thumbcontainer > figure > figcaption {
   margin: 0;
   padding: 12px 12px 24px 12px;
   background: #FFFFFF;
   text-align: center;
 }
 
-.gallery-item-thumbcontainer p.caption > a.headerlink {
+.gallery-item-thumbcontainer p.caption > a.headerlink,
+.gallery-item-thumbcontainer figure figcaption > a.headerlink,
+.gallery-item-thumbcontainer > figure > figcaption > a.headerlink {
   display: none;
 }
 
-.gallery-item-thumbcontainer p.caption .caption-text {
+.gallery-item-thumbcontainer p.caption .caption-text,
+.gallery-item-thumbcontainer figure figcaption p,
+.gallery-item-thumbcontainer > figure > figcaption > p {
   color: #515151;
   font-family: Roboto, sans-serif;
   font-size: 15px;
@@ -3458,10 +3464,13 @@ pre {
   text-align: center;
   word-wrap: break-word;
   overflow-wrap: break-word;
+  margin: 0;
 }
 
 .gallery-item-thumbcontainer:hover p.caption .caption-text,
-.gallery-item-thumbcontainer:hover p.caption .caption-text a {
+.gallery-item-thumbcontainer:hover p.caption .caption-text a,
+.gallery-item-thumbcontainer:hover figure figcaption p,
+.gallery-item-thumbcontainer:hover > figure > figcaption > p {
   color: #232323;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -1157,7 +1157,7 @@ div.topic.contents>ul>li {
   font-weight: bold !important;
   font-size: 16px;
   line-height: 1.1;
-  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .admonition.danger,
@@ -4164,6 +4164,10 @@ p.sphx-glr-signature a.reference.external {
     color: #232323;
 }
 
+.video-card .card-title {
+    font-family: Roboto, sans-serif !important;
+}
+
 .video-card {
     margin: 0;
     overflow: hidden;
@@ -4171,7 +4175,7 @@ p.sphx-glr-signature a.reference.external {
     width: 100%;
     min-width: 0;
     border: 0.5px solid #cfcfcf;
-    border-radius: 4px;
+    border-radius: 4px !important;
     background-color: #ffffff;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);
     transition: border 150ms ease, box-shadow 150ms ease, background-color 150ms ease;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -79,6 +79,13 @@ a:focus {
   text-decoration: underline;
 }
 
+/* Keep header permalink anchors neutral on interaction. */
+a.headerlink:hover,
+a.headerlink:focus {
+  color: #ddd;
+  text-decoration: none;
+}
+
 /* Keep button-like controls free of link underlines. */
 a.btn:hover,
 a.btn:focus,

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -4055,69 +4055,112 @@ p.sphx-glr-signature a.reference.external {
     margin-top: 20px;
 }
 
-.video-card h5 {
-  padding-left: 20px;
-  padding-right: 20px;
-  padding-bottom: 5px;
-}
-
 .video-card h4 {
-    margin-top: 10px;
-    font-weight: 300;
-    color: #535353;
+    margin: 0;
+    font-family: Roboto, sans-serif;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.5;
+    color: #232323;
 }
 
 .video-card {
-    margin-right: 0;
+    margin: 0;
     overflow: hidden;
     max-width: none;
     width: 100%;
-    margin-bottom: 30px;
-    background-color: #fff;
-    box-shadow: 0 2px 5px 0 rgba(0,0,0,.05),0 2px 25px 2px rgba(0,0,0,.2) !important;
+    min-width: 0;
+    border: 0.5px solid #cfcfcf;
+    border-radius: 4px;
+    background-color: #ffffff;
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);
+    transition: border 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
 }
 
 .video-card .card-body {
     z-index: 2;
-    box-sizing: content-box;
-    padding-top: 20px;
+    box-sizing: border-box;
+    padding: 16px;
     position: relative;
-    background-color: #fff;
-    margin-bottom: 45px;
+    background-color: #ffffff;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 .video-card:hover {
-    border: 0;
-    transition-duration: 0.4s;
-    border-radius: 10px!important;
+    border: 1px solid #cfcfcf;
+    border-radius: 4px !important;
+    background-color: #f5f5f5;
+    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.06), 0 4px 3px 0 rgba(0, 0, 0, 0.07);
 }
 
 
+.video-card__media {
+    padding: 16px 16px 0 16px;
+    background-color: #ffffff;
+}
+
 .video-card img {
-    transform: scale(1);
-    transition-duration: 1s;
+    display: block;
+    width: 100%;
+    aspect-ratio: 397 / 223;
+    object-fit: cover;
+    border-radius: 2px;
+    transform: none;
+    transition: none;
+}
+
+.video-card:hover .video-card__media,
+.video-card:hover .card-body,
+.video-card:hover .video-card__footer {
+    background-color: #f5f5f5;
 }
 
 .video-card p {
-    font-weight: 300;
+    margin: 0;
+    font-family: Roboto, sans-serif;
+    font-weight: 400;
+    font-size: 15px;
+    line-height: 1.4;
     color: #9e9e9e;
 }
 
-.video-card:hover img {
-    transform: scale(1.10);
-    transition-duration: 1s;
+.video-card__author {
+    color: #757575;
 }
 
-.video-card .watch hr{
-  position: absolute;
-  bottom: 25px;
-  width: 100%;
+.video-card__description {
+    color: #757575;
 }
 
-.video-card .watch h5{
-    right: 20px;
-    position: absolute;
-    bottom: 0;
+.video-card__footer {
+    background-color: #f5f5f5;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+    min-height: 56px;
+    padding: 12px 16px;
+}
+
+.video-card__watch-label {
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.4;
+    color: #0074E0;
+}
+
+.video-card__watch-icon {
+    color: #0074E0;
+    font-size: 20px;
+    line-height: 1;
+}
+
+.video-card:hover .video-card__watch-label,
+.video-card:hover .video-card__watch-icon {
+    color: #0055A5;
 }
 
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3300,12 +3300,19 @@ pre {
   float: none;
 }
 
+.gallery-grid {
+  --bs-gutter-x: 0;
+  --bs-gutter-y: 0;
+}
+
 /* Bootstrap 5 applies `.row > * { width: 100% }`. Gallery items are wrapped
    in paragraph nodes by the directive, so reset those wrappers to auto width. */
 .gallery-grid > p {
   flex: 0 0 auto;
   width: auto;
-  margin-bottom: 0;
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .gallery-item-thumbcontainer:hover {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3342,6 +3342,20 @@ pre {
   position: static;
 }
 
+.gallery-item-thumbcontainer p.caption .caption-text a::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  content: "";
+}
+
+.gallery-item-thumbcontainer {
+  cursor: pointer;
+}
+
 /* This avoids the Sphinx traditional theme which covers all of the thumbnail
   with its default link background color */
 .gallery-item-thumbcontainer a.reference:hover {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3371,6 +3371,19 @@ pre {
   z-index: 99;
 }
 
+/* Index card */
+/*-------------------------------------------*/
+
+.index-card-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.index-card-link:hover {
+  text-decoration: none;
+  color: inherit;
+}
+
 
 /* Plugin card */
 /*-------------------------------------------*/

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -1928,6 +1928,7 @@ nav {
   background-color: #FFFFFF;
   border-width: 0px;
   padding: 0;
+  text-decoration: none;
 }
 
 .desktop.navbar-left-link > a > i,
@@ -1942,6 +1943,7 @@ nav {
 .desktop.navbar-left-link button:hover {
   color: {{ theme_border_colour }};
   transition-duration: 0.15s;
+  text-decoration: none;
 }
 
 .desktop.navbar-left-link a:focus:not(:focus-visible),
@@ -1989,6 +1991,7 @@ nav {
 
 .desktop.navbar-right-links a {
   display: flex;
+  text-decoration: none;
 }
 
 .desktop.navbar-right-links a i {
@@ -2058,6 +2061,7 @@ nav {
   font-size: 16px;
   line-height: 150%;
   width: 100%;
+  text-decoration: none;
 }
 
 .desktop.navbar-dropdown li:hover a {
@@ -2162,6 +2166,7 @@ nav {
   display: flex;
   flex-direction: row;
   gap: 8px;
+  text-decoration: none;
 }
 
 .mobile.navbar-link-heading > a {
@@ -2215,6 +2220,7 @@ nav {
   font-weight: 400;
   line-height: 21px;
   transition: opacity 300ms, color 300ms, background-color 300ms;
+  text-decoration: none;
 }
 
 .mobile.navbar-button a:active {
@@ -2263,6 +2269,7 @@ nav {
   font-weight: 400;
   gap: 8px;
   line-height: 20px;
+  text-decoration: none;
 }
 
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3407,6 +3407,10 @@ pre {
     margin-bottom: auto;
 }
 
+.plugin-card__meta {
+    font-size: 0.875rem;
+}
+
 .plugin-card .plugin-logo {
     height: 35px;
     width: unset;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3565,7 +3565,16 @@ pre {
   text-decoration: none;
 }
 
+.title-card-link {
+  display: flex;
+  width: 100%;
+}
+
 .title-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
   border-radius: 4px !important;
   border: 0.5px solid #CFCFCF;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
@@ -3603,8 +3612,9 @@ pre {
 .title-card-body {
   padding: 12px 16px;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  flex: 1;
+  justify-content: flex-start;
+  align-items: flex-start;
   align-self: stretch;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3406,6 +3406,7 @@ pre {
 
 .gallery-item-thumbcontainer {
   cursor: pointer;
+  min-height: 220px;
 }
 
 /* This avoids the Sphinx traditional theme which covers all of the thumbnail
@@ -3620,7 +3621,7 @@ pre {
 .title-card {
   display: flex;
   flex-direction: column;
-  min-height: 180px;
+  min-height: 220px;
   height: 100%;
   width: 100%;
   border-radius: 4px !important;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3419,6 +3419,60 @@ pre {
   color: inherit;
 }
 
+.index-card {
+  border-radius: 4px !important;
+  border: 0.5px solid #CFCFCF;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
+  overflow: hidden;
+  transition: box-shadow 150ms ease, border 150ms ease;
+}
+
+.index-card:hover {
+  border: 1px solid #CFCFCF;
+  box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.07), 0 2px 2px 0 rgba(0, 0, 0, 0.06) !important;
+}
+
+.index-card-header {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  background: #F5F5F5;
+}
+
+.index-card-title {
+  margin: 0;
+  color: #0074E0;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 150%;
+}
+
+.index-card:hover .index-card-title {
+  color: #0055A5;
+}
+
+.index-card-body {
+  padding: 12px 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: stretch;
+}
+
+.index-card-description {
+  margin: 0;
+  width: 100%;
+  color: #757575;
+  font-family: Roboto, sans-serif;
+  font-size: 15px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
 .title-card-link,
 .title-card-link:hover,
 .title-card-link:focus {
@@ -3430,10 +3484,12 @@ pre {
   border: 0.5px solid #CFCFCF;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
   overflow: hidden;
+  transition: box-shadow 150ms ease, border 150ms ease;
 }
 
 .title-card:hover {
-  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
+  border: 1px solid #CFCFCF;
+  box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.07), 0 2px 2px 0 rgba(0, 0, 0, 0.06) !important;
 }
 
 .title-card-header {
@@ -3453,6 +3509,10 @@ pre {
   line-height: 150%;
 }
 
+.title-card:hover .title-card-title {
+  color: #0055A5;
+}
+
 .title-card-body {
   padding: 12px 16px;
   display: flex;
@@ -3463,6 +3523,13 @@ pre {
 
 .title-card-description {
   margin: 0;
+  width: 100%;
+  color: #757575;
+  font-family: Roboto, sans-serif;
+  font-size: 15px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.4;
 }
 
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3548,7 +3548,7 @@ pre {
 .index-card-title {
   margin: 0;
   color: #0074E0;
-  font-family: Roboto, sans-serif;
+  font-family: Roboto, sans-serif !important;
   font-size: 16px;
   font-style: normal;
   font-weight: 600;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3628,127 +3628,175 @@ pre {
 
 .plugin-card {
     z-index: 1;
-    transition-duration: 0.4s;
-    box-shadow: 0 2px 5px 0 rgba(0,0,0,.05),0 2px 25px 2px rgba(0,0,0,.05) !important;
     height: 100%;
-}
-
-.plugin-card:hover {
-    transition-duration: 0.4s;
-    box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .05), 0 2px 25px 2px rgba(0, 0, 0, .15) !important;
-}
-
-.plugin-card.active {
-    box-shadow: 0 2px 5px 0 rgba(204, 204, 204, 0.97),0 2px 15px 2px rgba(43, 187, 173, 0.6) !important;
-}
-
-.plugin-card img {
-    max-width: 60%;
+    border: 0.5px solid #cfcfcf;
+    border-radius: 4px;
+    background: #fff;
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);
+    overflow: hidden;
 }
 
 .plugin-card .card-header {
-    margin-top: 0px;
-    border-radius: 10px 10px 0 0;
-    min-height: 85px;
+    margin-top: 0;
+    border-radius: 0;
+    min-height: 0;
     display: flex;
-    background-color: #f3f8fc;
-    border-bottom: 1px solid #e4edf5;
-}
-
-.plugin-card .row {
-    height: 100%;
+    flex-direction: column;
+    gap: 8px;
+    background-color: #fff;
+    border: 0;
+    padding: 16px;
 }
 
 .card-header__text {
-    margin-top: auto;
-    margin-bottom: auto;
+    margin: 0;
+    font-family: Quicksand, sans-serif;
+    font-size: 20px;
+    font-weight: 500;
+    line-height: 1.2;
+    color: #232323;
 }
 
-.plugin-card__meta {
-    font-size: 0.875rem;
-    color: #6f6f6f;
-    margin-bottom: 0.5rem;
-}
-
-.plugin-card .plugin-logo {
-    height: 35px;
-    width: unset;
-    right: 20px;
-    position: absolute;
-    top: 14px;
-}
-
-.plugin-card__buttons {
-    margin-top: auto;
-    margin-bottom: auto;
-    width: 100%;
-}
-
-.plugin-card__description {
-    height: 110px;
-    overflow: hidden;
-    font-size: .9rem;
-    font-weight: 400;
-    color: #747373;
-    margin-bottom: .75rem;
-    position: relative;
-}
-
-.plugin-card__description:after {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: -15px;
-    right: -15px;
-    pointer-events: none;
-    box-shadow: inset 0px -40px 25px -15px white;
-}
-
-.plugin-card__description--no-overflow:after {
-    display: none;
-}
-
-.plugin-card__buttons .plugin-card__paper-btn,
-.plugin-card__buttons .plugin-card__blog-btn,
-.plugin-card__buttons .plugin-card__code-btn,
-.modal-footer .plugin-card__paper-btn,
-.modal-footer .plugin-card__blog-btn,
-.modal-footer .plugin-card__code-btn,
-.plugin-card__buttons .plugin-card__paper-btn:hover,
-.plugin-card__buttons .plugin-card__blog-btn:hover,
-.plugin-card__buttons .plugin-card__code-btn:hover,
-.modal-footer .plugin-card__paper-btn:hover,
-.modal-footer .plugin-card__blog-btn:hover,
-.modal-footer .plugin-card__code-btn:hover {
-    box-shadow: unset;
-    border-radius: 4px;
-}
-
-.plugin-card__buttons .plugin-card__paper-btn,
-.plugin-card__buttons .plugin-card__blog-btn,
-.plugin-card__buttons .plugin-card__code-btn {
-    margin: 0 0 0.375rem 0;
-    min-height: 40px;
-    width: 100%;
-    padding: 0 20px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 12px;
+.plugin-card__author {
+    margin: 0;
     font-family: Roboto, sans-serif;
     font-size: 15px;
     font-weight: 400;
     line-height: 1.4;
+    color: #232323;
 }
 
-.modal-footer .plugin-card__code-btn {
+.plugin-card__meta {
+    font-family: Roboto, sans-serif;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+    color: #757575;
     margin: 0;
 }
 
-.modal-footer .plugin-card__paper-btn,
-.modal-footer .plugin-card__blog-btn {
-    margin: 0 .25rem 0 0;
+.plugin-card .card-body {
+    padding: 0 16px 16px;
+    background-color: #fff;
+}
+
+.plugin-card__description-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.plugin-card__description {
+    margin: 0;
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.4;
+    color: #515151;
+}
+
+.plugin-card__description--preview {
+    position: relative;
+    max-height: calc(1.4em * 4);
+    overflow: hidden;
+}
+
+.plugin-card__description--preview:after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 2.5em;
+    pointer-events: none;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.7) 100%);
+}
+
+.plugin-card__description-collapse.show + .plugin-card__description--preview {
+    display: none;
+}
+
+.plugin-card__read-more {
+    display: inline-flex;
+    align-items: center;
+    min-height: 32px;
+    padding: 0;
+    width: fit-content;
+    color: #0074E0;
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.4;
+    text-decoration: none;
+}
+
+.plugin-card__read-more:hover,
+.plugin-card__read-more:focus {
+    color: #0055A5;
+    text-decoration: none;
+}
+
+.plugin-card__read-more-label-expanded {
+    display: none;
+}
+
+.plugin-card__description-collapse.show ~ .plugin-card__read-more .plugin-card__read-more-label-collapsed {
+    display: none;
+}
+
+.plugin-card__description-collapse.show ~ .plugin-card__read-more .plugin-card__read-more-label-expanded {
+    display: inline;
+}
+
+.plugin-card__footer {
+    background: #f5f5f5;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 12px 16px;
+}
+
+.plugin-card__action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 32px;
+    padding: 0;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: #0074E0;
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.4;
+    text-decoration: none;
+}
+
+.plugin-card__action-btn:hover,
+.plugin-card__action-btn:focus {
+    background: transparent;
+    color: #0055A5;
+    text-decoration: none;
+}
+
+.plugin-card__action-btn i {
+    font-size: 20px;
+    line-height: 1;
+}
+
+.plugin-card__action-btn--outlined {
+    border: 1px solid #0074E0;
+    background: #fff;
+    padding: 0 12px;
+}
+
+.plugin-card__action-btn--outlined:hover,
+.plugin-card__action-btn--outlined:focus {
+    border-color: #0055A5;
+    background: #fff;
 }
 
 .modal {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3639,9 +3639,13 @@ pre {
 
 /* Override generic `.card:hover` so community cards match Figma states. */
 .plugin-card:hover,
+.plugin-card:focus,
 .plugin-card:focus-within {
-    border-color: #cfcfcf;
+    border: 0.5px solid #cfcfcf;
+    border-radius: 4px;
+    background: #fff;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
+    outline: none;
 }
 
 .plugin-card .card-header {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3425,6 +3425,46 @@ pre {
   text-decoration: none;
 }
 
+.title-card {
+  border-radius: 4px !important;
+  border: 0.5px solid #CFCFCF;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
+  overflow: hidden;
+}
+
+.title-card:hover {
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
+}
+
+.title-card-header {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  background: #F5F5F5;
+}
+
+.title-card-title {
+  color: #0074E0;
+  font-family: Roboto, sans-serif;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 150%;
+}
+
+.title-card-body {
+  padding: 12px 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: stretch;
+}
+
+.title-card-description {
+  margin: 0;
+}
+
 
 /* Plugin card */
 /*-------------------------------------------*/

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3620,6 +3620,7 @@ pre {
 .title-card {
   display: flex;
   flex-direction: column;
+  min-height: 180px;
   height: 100%;
   width: 100%;
   border-radius: 4px !important;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3396,6 +3396,8 @@ pre {
     border-radius: 10px 10px 0 0;
     min-height: 85px;
     display: flex;
+    background-color: #f3f8fc;
+    border-bottom: 1px solid #e4edf5;
 }
 
 .plugin-card .row {
@@ -3409,6 +3411,8 @@ pre {
 
 .plugin-card__meta {
     font-size: 0.875rem;
+    color: #6f6f6f;
+    margin-bottom: 0.5rem;
 }
 
 .plugin-card .plugin-logo {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3342,7 +3342,7 @@ pre {
 
 .gallery-item-thumbcontainer {
   background: #fff;
-  border: 0.5px solid #CFCFCF;
+  border: 1px solid #CFCFCF;
   border-radius: 4px;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);
   display: flex;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3300,6 +3300,14 @@ pre {
   float: none;
 }
 
+/* Bootstrap 5 applies `.row > * { width: 100% }`. Gallery items are wrapped
+   in paragraph nodes by the directive, so reset those wrappers to auto width. */
+.gallery-grid > p {
+  flex: 0 0 auto;
+  width: auto;
+  margin-bottom: 0;
+}
+
 .gallery-item-thumbcontainer:hover {
   border: solid #b4ddfc 0px;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .05), 0 2px 25px 2px rgba(0, 0, 0, .2);

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3296,6 +3296,10 @@ pre {
   transition: 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 
+.gallery-grid .gallery-item-thumbcontainer {
+  float: none;
+}
+
 .gallery-item-thumbcontainer:hover {
   border: solid #b4ddfc 0px;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .05), 0 2px 25px 2px rgba(0, 0, 0, .2);

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -68,14 +68,15 @@ a.headerlink {
 }
 
 a {
-  color: #2a6496;
+  color: #0074E0;
   word-wrap: break-word;
   text-decoration: none;
 }
 
 a:hover,
 a:focus {
-  text-decoration: none;
+  color: #0074E0;
+  text-decoration: underline;
 }
 
 h1:hover>a.headerlink,

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3515,7 +3515,7 @@ pre {
 
 .index-card {
   border-radius: 4px !important;
-  border: 0.5px solid #CFCFCF;
+  border: 1px solid #CFCFCF;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
   overflow: hidden;
   transition: box-shadow 150ms ease, border 150ms ease;
@@ -3586,7 +3586,7 @@ pre {
   height: 100%;
   width: 100%;
   border-radius: 4px !important;
-  border: 0.5px solid #CFCFCF;
+  border: 1px solid #CFCFCF;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
   overflow: hidden;
   transition: box-shadow 150ms ease, border 150ms ease;
@@ -4176,7 +4176,7 @@ p.sphx-glr-signature a.reference.external {
     max-width: none;
     width: 100%;
     min-width: 0;
-    border: 0.5px solid #cfcfcf;
+    border: 1px solid #cfcfcf;
     border-radius: 4px !important;
     background-color: #ffffff;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3429,6 +3429,7 @@ pre {
 
 .index-card:hover {
   border: 1px solid #CFCFCF;
+  border-radius: 4px !important;
   box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.07), 0 2px 2px 0 rgba(0, 0, 0, 0.06) !important;
 }
 
@@ -3489,6 +3490,7 @@ pre {
 
 .title-card:hover {
   border: 1px solid #CFCFCF;
+  border-radius: 4px !important;
   box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.07), 0 2px 2px 0 rgba(0, 0, 0, 0.06) !important;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2883,6 +2883,7 @@ dd>.collapse-header {
   justify-content: space-between;
   border-bottom: 1px solid #cfcfcf;
   padding: 32px 0 8px 0;
+  margin-bottom: 12px;
   color: #232323;
   text-decoration: none;
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2911,6 +2911,10 @@ dd>.collapse-header {
   transition: transform 0.1s linear;
 }
 
+.collapse-header[aria-expanded="true"] i.rotate {
+  transform: rotate(180deg);
+}
+
 .collapse-header i.rotate.up {
   transform: rotate(180deg);
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -79,6 +79,14 @@ a:focus {
   text-decoration: underline;
 }
 
+/* Keep button-like controls free of link underlines. */
+a.btn:hover,
+a.btn:focus,
+button:hover,
+button:focus {
+  text-decoration: none;
+}
+
 h1:hover>a.headerlink,
 h2:hover>a.headerlink,
 h3:hover>a.headerlink,
@@ -260,6 +268,17 @@ blockquote {
   color: #ffffff;
   background-color: {{ theme_prev_next_button_colour }};
   border: none;
+  min-height: 40px;
+  padding: 0 20px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  font-family: Roboto, sans-serif;
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 1.4;
 }
 
 .btn-xanadu:hover,
@@ -3698,15 +3717,24 @@ pre {
 .modal-footer .plugin-card__blog-btn:hover,
 .modal-footer .plugin-card__code-btn:hover {
     box-shadow: unset;
-    border-radius: 5px;
+    border-radius: 4px;
 }
 
 .plugin-card__buttons .plugin-card__paper-btn,
 .plugin-card__buttons .plugin-card__blog-btn,
 .plugin-card__buttons .plugin-card__code-btn {
     margin: 0 0 0.375rem 0;
-    max-height: 45px;
+    min-height: 40px;
     width: 100%;
+    padding: 0 20px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    font-family: Roboto, sans-serif;
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 1.4;
 }
 
 .modal-footer .plugin-card__code-btn {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2858,21 +2858,38 @@ dd>.collapse-header {
   margin-top: 60px;
 }
 
-.collapse-header,
-.collapse-header:hover,
-.collapse-header:focus {
+.collapse-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #cfcfcf;
+  padding: 32px 0 8px 0;
+  color: #232323;
   text-decoration: none;
 }
 
-.rotate {
-  -moz-transition: all .1s linear;
-  -webkit-transition: all .1s linear;
-  transition: all .1s linear;
+.collapse-header:hover,
+.collapse-header:focus {
+  color: #232323;
+  text-decoration: none;
 }
 
-.rotate.up {
-  -moz-transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
+.collapse-header h2 {
+  font-family: 'Quicksand', sans-serif;
+  font-weight: 500;
+  font-size: 24px;
+  line-height: 1.2;
+  color: #232323;
+  margin: 0;
+}
+
+.collapse-header i.rotate {
+  font-size: 24px;
+  flex-shrink: 0;
+  transition: transform 0.1s linear;
+}
+
+.collapse-header i.rotate.up {
   transform: rotate(180deg);
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3533,6 +3533,7 @@ pre {
   align-items: center;
   align-self: stretch;
   background: #F5F5F5;
+  border-bottom: 0;
 }
 
 .index-card-title {
@@ -3603,6 +3604,7 @@ pre {
   align-items: center;
   align-self: stretch;
   background: #F5F5F5;
+  border-bottom: 0;
 }
 
 .title-card-title {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3724,8 +3724,14 @@ pre {
     background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0.7) 100%);
 }
 
-.plugin-card__description-collapse.show + .plugin-card__description--preview {
+.plugin-card__description-collapse.show + .plugin-card__description--preview,
+.plugin-card__description-collapse.collapsing + .plugin-card__description--preview {
     display: none;
+}
+
+.plugin-card__description-collapse.collapsing {
+    transition: height 220ms ease;
+    will-change: height;
 }
 
 .plugin-card__read-more {
@@ -3754,11 +3760,13 @@ pre {
     display: none;
 }
 
-.plugin-card__description-collapse.show ~ .plugin-card__read-more .plugin-card__read-more-label-collapsed {
+.plugin-card__description-collapse.show ~ .plugin-card__read-more .plugin-card__read-more-label-collapsed,
+.plugin-card__description-collapse.collapsing ~ .plugin-card__read-more .plugin-card__read-more-label-collapsed {
     display: none;
 }
 
-.plugin-card__description-collapse.show ~ .plugin-card__read-more .plugin-card__read-more-label-expanded {
+.plugin-card__description-collapse.show ~ .plugin-card__read-more .plugin-card__read-more-label-expanded,
+.plugin-card__description-collapse.collapsing ~ .plugin-card__read-more .plugin-card__read-more-label-expanded {
     display: inline;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2881,6 +2881,9 @@ dd>.collapse-header {
   line-height: 1.2;
   color: #232323;
   margin: 0;
+  padding: 0;
+  border: 0;
+  text-decoration: none;
 }
 
 .collapse-header i.rotate {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3345,9 +3345,10 @@ pre {
   border: 1px solid #CFCFCF;
   border-radius: 4px;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
-  float: left;
+  float: none;
+  vertical-align: top;
   margin: 12px;
   min-width: 220px;
   width: 220px;
@@ -3573,6 +3574,36 @@ pre {
 .title-card-link:hover,
 .title-card-link:focus {
   text-decoration: none;
+}
+
+/* Fallback layout for pages that place consecutive title-card directives
+   without an explicit Bootstrap `.row` wrapper (e.g. legacy docs pages). */
+.title-card-col {
+  display: inline-flex;
+  width: 33.3333%;
+  box-sizing: border-box;
+  padding-right: 12px;
+  vertical-align: top;
+}
+
+@media (max-width: 991.98px) {
+  .title-card-col {
+    width: 50%;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .title-card-col {
+    width: 100%;
+    padding-right: 0;
+  }
+}
+
+/* When title cards are already inside a `.row`, defer to Bootstrap grid. */
+.row > .title-card-col {
+  display: flex;
+  width: auto;
+  padding-right: 0;
 }
 
 .title-card-link {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -14,6 +14,10 @@ body {
   min-height: calc(100vh - 90px);
 }
 
+.grey-text {
+  color: #9e9e9e;
+}
+
 .css-transitions-only-after-page-load * {
   -webkit-transition: none !important;
   -moz-transition: none !important;
@@ -66,6 +70,12 @@ a.headerlink {
 a {
   color: #2a6496;
   word-wrap: break-word;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: none;
 }
 
 h1:hover>a.headerlink,

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3374,7 +3374,6 @@ pre {
   width: 100%;
   height: 140px;
   object-fit: contain;
-  background: rgba(230, 241, 252, 0.8);
   padding: 12px 12px 0 12px;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3297,19 +3297,18 @@ pre {
 
 .gallery-item-thumbcontainer {
   background: #fff;
-  border: solid #dedede 0px;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
-  border-radius: 5px;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .05), 0 2px 25px 2px rgba(0, 0, 0, .08);
+  border: 0.5px solid #CFCFCF;
+  border-radius: 4px;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);
+  display: flex;
+  flex-direction: column;
   float: left;
   margin: 12px;
-  min-height: 230px;
-  padding-top: 5px;
+  min-width: 220px;
+  width: 220px;
+  overflow: hidden;
   position: relative;
-  text-align: center;
-  border-radius: 10px;
-  transition: 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: box-shadow 150ms ease, border 150ms ease;
 }
 
 .gallery-grid .gallery-item-thumbcontainer {
@@ -3332,52 +3331,76 @@ pre {
 }
 
 .gallery-item-thumbcontainer:hover {
-  border: solid #b4ddfc 0px;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .05), 0 2px 25px 2px rgba(0, 0, 0, .2);
-  transition: 0.5s cubic-bezier(0.25, 0.1, 0.25, 1);
+  border: 1px solid #CFCFCF;
+  border-radius: 4px;
+  box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.07), 0 2px 2px 0 rgba(0, 0, 0, 0.06);
 }
 
 .gallery-item-thumbcontainer a.reference {
-  bottom: 0;
-  display: flex;
-  left: 0;
-  justify-content: center;
-  align-items: flex-begin;
-  padding: 150px 10px 0 10px;
-  position: absolute;
-  right: 0;
-  top: 0;
-  color: #575757;
+  color: inherit;
+  position: static;
 }
 
 /* This avoids the Sphinx traditional theme which covers all of the thumbnail
   with its default link background color */
 .gallery-item-thumbcontainer a.reference:hover {
   background-color: transparent;
-  color: #575757;
+  color: inherit;
   text-decoration: none;
 }
 
 .gallery-item-thumbcontainer p {
-  margin: 0 0 .1em 0;
+  margin: 0;
 }
 
 .gallery-item-thumbcontainer > div.figure,
 .gallery-item-thumbcontainer > figure {
-  padding-bottom: 10px;
-  padding-top: 10px;
+  padding: 0;
+  margin: 0;
+  width: 100%;
 }
 
 .gallery-item-thumbcontainer .figure,
 .gallery-item-thumbcontainer figure {
-  margin: 10px;
-  width: 160px;
+  margin: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #FFFFFF;
 }
 
 .gallery-item-thumbcontainer img {
-  display: inline;
-  max-height: 160px;
-  max-width: 160px;
+  display: block;
+  width: 100%;
+  height: 140px;
+  object-fit: contain;
+  background: rgba(230, 241, 252, 0.8);
+  padding: 12px 12px 0 12px;
+}
+
+.gallery-item-thumbcontainer p.caption {
+  margin: 0;
+  padding: 12px 12px 24px 12px;
+  background: #FFFFFF;
+  text-align: center;
+}
+
+.gallery-item-thumbcontainer p.caption > a.headerlink {
+  display: none;
+}
+
+.gallery-item-thumbcontainer p.caption .caption-text {
+  color: #515151;
+  font-family: Roboto, sans-serif;
+  font-size: 15px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+.gallery-item-thumbcontainer:hover p.caption .caption-text,
+.gallery-item-thumbcontainer:hover p.caption .caption-text a {
+  color: #232323;
 }
 
 .gallery-item-thumbcontainer[tooltip]:hover:after {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3590,6 +3590,7 @@ pre {
   display: inline-flex;
   width: 33.3333%;
   box-sizing: border-box;
+  margin-bottom: 12px;
   padding-right: 12px;
   vertical-align: top;
 }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2845,6 +2845,12 @@ dl.class > dd > table.docutils {
 
 dd>.collapse-header {
   margin-top: 60px;
+  text-decoration: none;
+}
+
+dd>.collapse-header:hover,
+dd>.collapse-header:focus {
+  text-decoration: none;
 }
 
 .rotate {
@@ -3403,6 +3409,12 @@ pre {
   color: inherit;
 }
 
+.title-card-link,
+.title-card-link:hover,
+.title-card-link:focus {
+  text-decoration: none;
+}
+
 
 /* Plugin card */
 /*-------------------------------------------*/
@@ -3819,6 +3831,12 @@ p.sphx-glr-signature a.reference.external {
   height: 100% !important;
 }
 
+.youtube-video-link,
+.youtube-video-link:hover,
+.youtube-video-link:focus {
+  text-decoration: none;
+}
+
 .youtube-video-gallery li {
     margin-bottom: 20px;
     margin-top: 20px;
@@ -3837,9 +3855,10 @@ p.sphx-glr-signature a.reference.external {
 }
 
 .video-card {
-    margin-right: 28px;
+    margin-right: 0;
     overflow: hidden;
-    max-width: 375px;
+    max-width: none;
+    width: 100%;
     margin-bottom: 30px;
     background-color: #fff;
     box-shadow: 0 2px 5px 0 rgba(0,0,0,.05),0 2px 25px 2px rgba(0,0,0,.2) !important;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3634,6 +3634,14 @@ pre {
     background: #fff;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10);
     overflow: hidden;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+/* Override generic `.card:hover` so community cards match Figma states. */
+.plugin-card:hover,
+.plugin-card:focus-within {
+    border-color: #cfcfcf;
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
 }
 
 .plugin-card .card-header {
@@ -3734,6 +3742,8 @@ pre {
 .plugin-card__read-more:focus {
     color: #0055A5;
     text-decoration: none;
+    outline: none;
+    box-shadow: none;
 }
 
 .plugin-card__read-more-label-expanded {
@@ -3780,6 +3790,8 @@ pre {
     background: transparent;
     color: #0055A5;
     text-decoration: none;
+    outline: none;
+    box-shadow: none;
 }
 
 .plugin-card__action-btn i {
@@ -3797,6 +3809,15 @@ pre {
 .plugin-card__action-btn--outlined:focus {
     border-color: #0055A5;
     background: #fff;
+    outline: none;
+    box-shadow: none;
+}
+
+.plugin-card__read-more:focus-visible,
+.plugin-card__action-btn:focus-visible,
+.plugin-card__action-btn--outlined:focus-visible {
+    outline: none;
+    box-shadow: none;
 }
 
 .modal {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3696,6 +3696,11 @@ pre {
     transition: border-color 150ms ease, box-shadow 150ms ease;
 }
 
+/* Enforce community-card visual token values. */
+.community-card {
+    border-radius: 4px !important;
+}
+
 /* Override generic `.card:hover` so community cards match Figma states. */
 .plugin-card:hover,
 .plugin-card:focus,
@@ -3735,6 +3740,10 @@ pre {
     font-weight: 400;
     line-height: 1.4;
     color: #232323;
+}
+
+.community-card .plugin-card__author {
+    font-family: Roboto, sans-serif !important;
 }
 
 .plugin-card__meta {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3395,6 +3395,10 @@ pre {
   font-style: normal;
   font-weight: 400;
   line-height: 1.4;
+  display: block;
+  text-align: center;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .gallery-item-thumbcontainer:hover p.caption .caption-text,

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2856,11 +2856,11 @@ dl.class > dd > table.docutils {
 
 dd>.collapse-header {
   margin-top: 60px;
-  text-decoration: none;
 }
 
-dd>.collapse-header:hover,
-dd>.collapse-header:focus {
+.collapse-header,
+.collapse-header:hover,
+.collapse-header:focus {
   text-decoration: none;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3895,9 +3895,9 @@ p.sphx-glr-signature a.reference.external {
     transition-duration: 1s;
 }
 
-.video-card  p {
+.video-card p {
     font-weight: 300;
-    color: #eee;
+    color: #9e9e9e;
 }
 
 .video-card:hover img {

--- a/xanadu_sphinx_theme/templates/autosummary/class.rst
+++ b/xanadu_sphinx_theme/templates/autosummary/class.rst
@@ -14,9 +14,8 @@
    .. raw:: html
 
       <a class="attr-details-header collapse-header" data-bs-toggle="collapse" href="#attrDetails" aria-expanded="false" aria-controls="attrDetails">
-         <h2 style="font-size: 24px;">
-            <i class="fas fa-angle-down rotate" style="float: right;"></i> Attributes
-         </h2>
+         <h2>Attributes</h2>
+         <i class="bx bx-chevron-down rotate"></i>
       </a>
       <div class="collapse" id="attrDetails">
 
@@ -49,9 +48,8 @@
    .. raw:: html
 
       <a class="meth-details-header collapse-header" data-bs-toggle="collapse" href="#methDetails" aria-expanded="false" aria-controls="methDetails">
-         <h2 style="font-size: 24px;">
-            <i class="fas fa-angle-down rotate" style="float: right;"></i> Methods
-         </h2>
+         <h2>Methods</h2>
+         <i class="bx bx-chevron-down rotate"></i>
       </a>
       <div class="collapse" id="methDetails">
 
@@ -82,7 +80,7 @@
       <script type="text/javascript">
          document.querySelectorAll(".collapse-header").forEach((header) => {
              header.addEventListener("click", () => {
-                 const icon = header.querySelector("h2 i");
+                 const icon = header.querySelector("i.rotate");
                  if (icon !== null) {
                      icon.classList.toggle("up");
                  }

--- a/xanadu_sphinx_theme/templates/autosummary/class.rst
+++ b/xanadu_sphinx_theme/templates/autosummary/class.rst
@@ -13,7 +13,7 @@
 
    .. raw:: html
 
-      <a class="attr-details-header collapse-header" data-toggle="collapse" href="#attrDetails" aria-expanded="false" aria-controls="attrDetails">
+      <a class="attr-details-header collapse-header" data-bs-toggle="collapse" href="#attrDetails" aria-expanded="false" aria-controls="attrDetails">
          <h2 style="font-size: 24px;">
             <i class="fas fa-angle-down rotate" style="float: right;"></i> Attributes
          </h2>
@@ -48,7 +48,7 @@
 
    .. raw:: html
 
-      <a class="meth-details-header collapse-header" data-toggle="collapse" href="#methDetails" aria-expanded="false" aria-controls="methDetails">
+      <a class="meth-details-header collapse-header" data-bs-toggle="collapse" href="#methDetails" aria-expanded="false" aria-controls="methDetails">
          <h2 style="font-size: 24px;">
             <i class="fas fa-angle-down rotate" style="float: right;"></i> Methods
          </h2>
@@ -80,7 +80,12 @@
    .. raw:: html
 
       <script type="text/javascript">
-         $(".collapse-header").click(function () {
-             $(this).children('h2').eq(0).children('i').eq(0).toggleClass("up");
-         })
+         document.querySelectorAll(".collapse-header").forEach((header) => {
+             header.addEventListener("click", () => {
+                 const icon = header.querySelector("h2 i");
+                 if (icon !== null) {
+                     icon.classList.toggle("up");
+                 }
+             });
+         });
       </script>

--- a/xanadu_sphinx_theme/templates/autosummary_core/class.rst
+++ b/xanadu_sphinx_theme/templates/autosummary_core/class.rst
@@ -19,7 +19,7 @@
 
    .. raw:: html
 
-      <a class="attr-details-header collapse-header" data-toggle="collapse" href="#attrDetails" aria-expanded="false" aria-controls="attrDetails">
+      <a class="attr-details-header collapse-header" data-bs-toggle="collapse" href="#attrDetails" aria-expanded="false" aria-controls="attrDetails">
          <h2 style="font-size: 24px;">
             <i class="fas fa-angle-down rotate" style="float: right;"></i> Attributes
          </h2>
@@ -54,7 +54,7 @@
 
    .. raw:: html
 
-      <a class="meth-details-header collapse-header" data-toggle="collapse" href="#methDetails" aria-expanded="false" aria-controls="methDetails">
+      <a class="meth-details-header collapse-header" data-bs-toggle="collapse" href="#methDetails" aria-expanded="false" aria-controls="methDetails">
          <h2 style="font-size: 24px;">
             <i class="fas fa-angle-down rotate" style="float: right;"></i> Methods
          </h2>
@@ -86,7 +86,12 @@
    .. raw:: html
 
       <script type="text/javascript">
-         $(".collapse-header").click(function () {
-             $(this).children('h2').eq(0).children('i').eq(0).toggleClass("up");
-         })
+         document.querySelectorAll(".collapse-header").forEach((header) => {
+             header.addEventListener("click", () => {
+                 const icon = header.querySelector("h2 i");
+                 if (icon !== null) {
+                     icon.classList.toggle("up");
+                 }
+             });
+         });
       </script>

--- a/xanadu_sphinx_theme/templates/autosummary_core/class.rst
+++ b/xanadu_sphinx_theme/templates/autosummary_core/class.rst
@@ -20,9 +20,8 @@
    .. raw:: html
 
       <a class="attr-details-header collapse-header" data-bs-toggle="collapse" href="#attrDetails" aria-expanded="false" aria-controls="attrDetails">
-         <h2 style="font-size: 24px;">
-            <i class="fas fa-angle-down rotate" style="float: right;"></i> Attributes
-         </h2>
+         <h2>Attributes</h2>
+         <i class="bx bx-chevron-down rotate"></i>
       </a>
       <div class="collapse" id="attrDetails">
 
@@ -55,9 +54,8 @@
    .. raw:: html
 
       <a class="meth-details-header collapse-header" data-bs-toggle="collapse" href="#methDetails" aria-expanded="false" aria-controls="methDetails">
-         <h2 style="font-size: 24px;">
-            <i class="fas fa-angle-down rotate" style="float: right;"></i> Methods
-         </h2>
+         <h2>Methods</h2>
+         <i class="bx bx-chevron-down rotate"></i>
       </a>
       <div class="collapse" id="methDetails">
 
@@ -88,7 +86,7 @@
       <script type="text/javascript">
          document.querySelectorAll(".collapse-header").forEach((header) => {
              header.addEventListener("click", () => {
-                 const icon = header.querySelector("h2 i");
+                 const icon = header.querySelector("i.rotate");
                  if (icon !== null) {
                      icon.classList.toggle("up");
                  }


### PR DESCRIPTION
## Tickets
- [sc-82174-automate-release-and-version-bump-in-xanadu](https://app.shortcut.com/xanaduai/story/82174/automate-release-and-version-bump-in-xanadu-sphinx-theme)
- [sc-110105-replace-all-jquery-in-xanadu-sphinx-theme-to](https://app.shortcut.com/xanaduai/story/110105/replace-all-jquery-in-xanadu-sphinx-theme-to-allow-for-sphinx-version-bump)

## Summary

This PR removed jQuery/MDB and aligns core directive components with Bootstrap 5 and updated [Figma specs](https://www.figma.com/design/xMyjy9OgHUdVRUGC0H3bMd/Markdown-Guidelines--2025-?node-id=1893-258&t=XWTdHzMxKwp3ljYA-11), while fixing visual regressions discovered during QA.

- Also automated release GitHub actions similar to in PST [here](https://github.com/PennyLaneAI/pennylane-sphinx-theme/tree/master/.github).

## What changed

- Migrated theme assets/templates to Bootstrap 5-compatible behavior and removed legacy jQuery-dependent patterns.
- Updated directive output and styling for:
  - `details` (accordion header/icon behavior)
  - `community-card`
  - `youtube-video`
  - `title-card`
  - `index-card`
  - `gallery-item`
- Improved link and interaction consistency:
  - Global docs links use `#0074E0` with controlled hover behavior.
  - Header permalinks (`.headerlink`) now keep neutral hover/focus styling (no underline).
  - Button-like links no longer inherit unwanted underline styles.
- Fixed card/grid layout regressions:
  - Equal-height card behavior for title/index cards.
  - Fallback title-card layout for pages without explicit Bootstrap rows.
  - Removed `.row > .title-card-col { width: auto; }` override to restore proper Bootstrap column sizing.
- Improved gallery behavior:
  - Whole-card clickability support and caption handling for both legacy and HTML5 (`figcaption`) output.
  - Stabilized gallery card borders to avoid hover layout shift.
- Updated docs examples in `doc/directives.rst`:
  - Added stronger multi-card examples (including multi-row gallery and card layouts).
- Refined typography and visual parity details (e.g., Roboto/Quicksand usage, video card radius/title styling, admonition title font).
- Updated footer copyright text rendering order.

## Preview
- PennyLane Docs: https://xanaduai-pennylane--9227.com.readthedocs.build/en/9227/index.html
  - Do check that pages on preview link above look good compared to original docs link below
  - Original: https://docs.pennylane.ai/en/stable/
- XST: https://xanadu-sphinx-theme--103.org.readthedocs.build/en/103/
- PST: https://xanaduai-pennylane--161.com.readthedocs.build/projects/sphinx-theme/en/161/

## Related PRs
- https://github.com/PennyLaneAI/pennylane-sphinx-theme/pull/161
- https://github.com/PennyLaneAI/pennylane/pull/9227