### PR TITLE
sc-117746-make-the-entrie-template-card-clickable-in

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Ashish Kanwar Singh](https://github.com/ashishks0522)
+
+### Bug fixes
+
+- Fixed title cards and index cards so the entire card is clickable, not just the title text. Cards now use Bootstrap's `stretched-link` pattern to cover the full card area.
+
 ## Release 0.18.0 (current release)
 
 ### Contributors

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,7 @@ This release contains contributions from (in alphabetical order):
 ### Bug fixes
 
 - Fixed title cards and index cards so the entire card is clickable, not just the title text. Cards now use Bootstrap's `stretched-link` pattern to cover the full card area.
+- Fixed gallery items so the full card (including the thumbnail image) is clickable when the description contains a link. Broadened the CSS overlay selectors to match all Sphinx figure caption markup variants.
 
 ## Release 0.18.0 (current release)
 

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -166,51 +166,51 @@ Gallery Item
         <div class="gallery-grid">
 
     .. gallery-item::
-        :description: Getting Started
+        :description: :doc:`Getting Started <started>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Installation
+        :description: :doc:`Installation <started>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Configuration
+        :description: :doc:`Configuration <configuration>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: API Reference
+        :description: :doc:`API Reference <code>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Development Guide - API
+        :description: :doc:`Development Guide <directives>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Plugin Tutorials  Quantum Chemistry
+        :description: :doc:`Plugin Tutorials <gallery>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Device Docs
+        :description: :doc:`Device Docs <elements>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Optimization
+        :description: :doc:`Optimization <elements>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Templates
+        :description: :doc:`Templates <directives>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Demos
+        :description: :doc:`Demos <gallery>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Machine Learning
+        :description: :doc:`Machine Learning <elements>`
         :figure: _static/teleport.png
 
     .. gallery-item::
-        :description: Quantum Chemistry
+        :description: :doc:`Quantum Chemistry <elements>`
         :figure: _static/teleport.png
 
     .. raw:: html
@@ -222,51 +222,51 @@ Gallery Item
     <div class="gallery-grid">
 
 .. gallery-item::
-    :description: Getting Started
+    :description: :doc:`Getting Started <started>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Installation
+    :description: :doc:`Installation <started>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Configuration
+    :description: :doc:`Configuration <configuration>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: API Reference
+    :description: :doc:`API Reference <code>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Development Guide
+    :description: :doc:`Development Guide <directives>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Plugin Tutorials
+    :description: :doc:`Plugin Tutorials <gallery>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Device Docs
+    :description: :doc:`Device Docs <elements>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Optimization
+    :description: :doc:`Optimization <elements>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Templates
+    :description: :doc:`Templates <directives>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Demos
+    :description: :doc:`Demos <gallery>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Machine Learning
+    :description: :doc:`Machine Learning <elements>`
     :figure: _static/teleport.png
 
 .. gallery-item::
-    :description: Quantum Chemistry
+    :description: :doc:`Quantum Chemistry <elements>`
     :figure: _static/teleport.png
 
 .. raw:: html

--- a/xanadu_sphinx_theme/directives/index_card.py
+++ b/xanadu_sphinx_theme/directives/index_card.py
@@ -8,19 +8,18 @@ from docutils.parsers.rst import Directive, directives
 TEMPLATE = cleandoc(
     """
     <div class="col-lg-4 mb-2 d-flex align-items-stretch">
-        <a class="index-card-link d-flex w-100" href="{link}">
-            <div class="card index-card h-100 w-100">
-                <div class="card-header index-card-header">
-                    <h3 class="index-card-title">{name}</h3>
-                </div>
-                <div class="card-body index-card-body">
-                    <p class="card-text index-card-description">
-                        {description}
-                        <i class="fas fa-angle-double-right"></i>
-                    </p>
-                </div>
+        <div class="card index-card h-100 w-100">
+            <div class="card-header index-card-header">
+                <h3 class="index-card-title">{name}</h3>
             </div>
-        </a>
+            <div class="card-body index-card-body">
+                <p class="card-text index-card-description">
+                    {description}
+                    <i class="fas fa-angle-double-right"></i>
+                </p>
+            </div>
+            <a class="index-card-link stretched-link" href="{link}" aria-label="{name}"></a>
+        </div>
     </div>
     """
 )

--- a/xanadu_sphinx_theme/directives/title_card.py
+++ b/xanadu_sphinx_theme/directives/title_card.py
@@ -8,16 +8,15 @@ from docutils.parsers.rst import Directive, directives
 TEMPLATE = cleandoc(
     """
     <div class="title-card-col col-lg-4">
-        <a class="title-card-link d-flex w-100" href="{link}">
-            <div class="card title-card h-100 w-100">
-                <div class="card-header title-card-header">
-                    <span class="title-card-title">{name}</span>
-                </div>
-                <div class="card-body title-card-body">
-                    <p class="card-text title-card-description">{description}</p>
-                </div>
+        <div class="card title-card h-100 w-100">
+            <div class="card-header title-card-header">
+                <span class="title-card-title">{name}</span>
             </div>
-        </a>
+            <div class="card-body title-card-body">
+                <p class="card-text title-card-description">{description}</p>
+            </div>
+            <a class="title-card-link stretched-link" href="{link}" aria-label="{name}"></a>
+        </div>
     </div>
     """
 )

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3394,7 +3394,10 @@ pre {
   position: static;
 }
 
-.gallery-item-thumbcontainer p.caption .caption-text a::after {
+.gallery-item-thumbcontainer p.caption a::after,
+.gallery-item-thumbcontainer p.caption .caption-text a::after,
+.gallery-item-thumbcontainer figure figcaption a::after,
+.gallery-item-thumbcontainer figure figcaption p a::after {
   position: absolute;
   top: 0;
   right: 0;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3517,12 +3517,15 @@ pre {
   color: inherit;
 }
 
-.index-card-link:hover {
+.index-card-link:hover,
+.index-card-link:focus {
   text-decoration: none;
   color: inherit;
 }
 
 .index-card {
+  position: relative;
+  cursor: pointer;
   border-radius: 4px !important;
   border: 1px solid #CFCFCF;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px 0 rgba(0, 0, 0, 0.10) !important;
@@ -3578,12 +3581,6 @@ pre {
   line-height: 1.4;
 }
 
-.title-card-link,
-.title-card-link:hover,
-.title-card-link:focus {
-  text-decoration: none;
-}
-
 /* Fallback layout for pages that place consecutive title-card directives
    without an explicit Bootstrap `.row` wrapper (e.g. legacy docs pages). */
 .title-card-col {
@@ -3614,12 +3611,22 @@ pre {
   padding-right: 0;
 }
 
-.title-card-link {
-  display: flex;
+.title-card-col > .title-card,
+.row > .title-card-col > .title-card {
+  flex: 1;
   width: 100%;
 }
 
+.title-card-link,
+.title-card-link:hover,
+.title-card-link:focus {
+  text-decoration: none;
+  color: inherit;
+}
+
 .title-card {
+  position: relative;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   min-height: 220px;


### PR DESCRIPTION
## Problem

Title cards and index cards only registered clicks on the title text. Clicks on the card body, padding, or empty space within the card did nothing because the link did not cover the full card area.

- [sc-117746-make-the-entrie-template-card-clickable-in](https://app.shortcut.com/xanaduai/story/117746/make-the-entrie-template-card-clickable-in-docs)

## Solution

- Move the anchor inside the card and apply Bootstrap's `stretched-link` class so the link overlay spans the entire card
- Add `aria-label` on the stretched link for accessibility
- Apply the same fix to both `title-card` and `index-card` directives for consistency

## Testing
- See updated behaviour [here](https://xanadu-sphinx-theme--108.org.readthedocs.build/en/108/directives.html)
- See broken behaviour [here](https://docs.pennylane.ai/en/latest/introduction/templates.html)

