### PR TITLE
[SC-121581] Port global `navbar` to sphinx documentation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Koeun Lee](https://github.com/koeun-lee)
+
+### Features
+
+- Ported PennyLane's new global navbar into the Sphinx theme.
+  - On desktop it expands into a "mega menu" with multi-column sections and a slide-down animation.
+  - On mobile it collapses into an accordion with expand/collapse animations.
+  - Menus render featured cards along with content and latest-release cards that are loaded client-side when a menu first opens.
+
+### Bug fixes
+
+- Navbar menus now close automatically when switching between mobile and desktop breakpoints.
+
 ## Release 0.19.0 (current release)
 
 ### Contributors

--- a/doc/sg_execution_times.rst
+++ b/doc/sg_execution_times.rst
@@ -1,0 +1,37 @@
+
+:orphan:
+
+.. _sphx_glr_sg_execution_times:
+
+
+Computation times
+=================
+**00:00.000** total execution time for 1 file **from all galleries**:
+
+.. container::
+
+  .. raw:: html
+
+    <style scoped>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet" />
+    </style>
+    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script type="text/javascript" class="init">
+    $(document).ready( function () {
+        $('table.sg-datatable').DataTable({order: [[1, 'desc']]});
+    } );
+    </script>
+
+  .. list-table::
+   :header-rows: 1
+   :class: table table-striped sg-datatable
+
+   * - Example
+     - Time
+     - Mem (MB)
+   * - :ref:`sphx_glr_gallery_tutorial_demo.py` (``tutorials/tutorial_demo.py``)
+     - 00:00.000
+     - 0.0

--- a/xanadu_sphinx_theme/footer.html
+++ b/xanadu_sphinx_theme/footer.html
@@ -57,7 +57,7 @@
             >
               <span class="footer-middle__link-name">{{ link.name }}</span>
               {% if link.get("external") %}
-              <i class="bx bx-arrow-out-up-right-square footer-middle__link-external-icon" aria-hidden="true"></i>
+              <i class="bx bx-link-external footer-middle__link-external-icon" aria-hidden="true"></i>
               {% endif %}
             </a>
           </li>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -134,28 +134,22 @@
      layout.html). The button is static, from the card config. #}
   {% macro render_release_card_slot(card_section, size, parent_name, group_id) %}
     {% set button = card_section.cards.button %}
-    <script type="application/json" class="release-card-config" data-group="{{ group_id }}">{"limit": {{ card_section.cards.limit }}}</script>
+    {% set variant = card_section.cards.variant %}
+    <script type="application/json" class="release-card-config" data-group="{{ group_id }}">{{ {"limit": card_section.cards.limit, "variant": variant, "button": button} | tojson }}</script>
     {% for i in range(card_section.cards.limit) %}
-      <a class="mega-menu-card MenuCard MenuCard--dark FeaturedMenuCard FeaturedMenuCard--{{ size }} FeaturedMenuCard--dark FeaturedMenuCard--{{ card_section.cards.variant }} release-menu-card release-menu-card--loading"
-         data-release-card-group="{{ group_id }}" data-release-card-index="{{ i }}"
-         data-parent-name="{{ parent_name }}"
-         href="#" aria-hidden="true" tabindex="-1">
-        <svg class="MenuCard__border-svg" aria-hidden="true">
-          <rect class="MenuCard__border-rect" rx="5" pathLength="400"></rect>
-        </svg>
-        <div class="FeaturedMenuCard__content">
-          <h4 class="FeaturedMenuCard__title FeaturedMenuCard__title--clamp-4"></h4>
+      <div class="ReleaseMenuCardSkeleton ReleaseMenuCardSkeleton--{{ size }} release-menu-card release-menu-card--loading"
+           data-release-card-group="{{ group_id }}" data-release-card-index="{{ i }}"
+           data-parent-name="{{ parent_name }}"
+           aria-hidden="true">
+        <div class="ReleaseMenuCardSkeleton__title-container">
+          <div class="ReleaseMenuCardSkeleton__title ReleaseMenuCardSkeleton__title-first-line"></div>
+          <div class="ReleaseMenuCardSkeleton__title ReleaseMenuCardSkeleton__title-second-line"></div>
+          <div class="ReleaseMenuCardSkeleton__title ReleaseMenuCardSkeleton__title-third-line"></div>
+          <div class="ReleaseMenuCardSkeleton__title ReleaseMenuCardSkeleton__title-fourth-line"></div>
         </div>
-        <div class="FeaturedMenuCard__image FeaturedMenuCard__image--full FeaturedMenuCard__image--placeholder release-menu-card__image" aria-hidden="true"></div>
-        <span class="FeaturedMenuCard__button FeaturedMenuCard__button--{{ button.variant }}">
-          <span class="FeaturedMenuCard__button-label">
-            <span>{{ button.text }}</span>
-            {% if button.icon %}
-              <i class="bx {{ button.icon }}"></i>
-            {% endif %}
-          </span>
-        </span>
-      </a>
+        <div class="ReleaseMenuCardSkeleton__image"></div>
+        <div class="ReleaseMenuCardSkeleton__button"></div>
+      </div>
     {% endfor %}
   {% endmacro %}
 

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -196,6 +196,8 @@
         <i class="bx bx-chevron-down"></i>
       </button>
       <div class="navbar-mega-menu desktop">
+        <div class="navbar-mega-menu__overflow">
+        <div class="navbar-mega-menu__resize">
         <div class="navbar-mega-menu__inner">
           <div class="navbar-mega-menu__links-area" style="--menu-link-total-columns: {{ ns.total_columns }};">
             {% for link_section in link.linkSections %}
@@ -262,6 +264,8 @@
               </div>
             {% endif %}
           {% endif %}
+        </div>
+        </div>
         </div>
       </div>
     </li>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -296,6 +296,9 @@
   </div>
 </nav>
 
+<!-- Dimmed backdrop shown while a desktop mega menu is open. -->
+<div class="navbar-overlay" aria-hidden="true"></div>
+
 <div class="navbar-links mobile">
   <ul>
     {% if theme_command_palette_enabled|lower == 'true' %}

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -74,11 +74,6 @@
   {# Renders a single featured navbar card (pennylane-app's FeaturedMenuCard).
      size is 'desktop' or 'mobile'. #}
   {% macro render_featured_card(card, size, parent_name) %}
-    {% set icon_map = {
-      'BiRightArrowAlt': 'bx-right-arrow-alt',
-      'BiLinkExternal': 'bx-link-external',
-      'BiChevronRight': 'bx-chevron-right',
-    } %}
     {% set light_variants = ['white', 'soft-blue', 'confetti'] %}
     {% set theme = 'light' if card.variant in light_variants else 'dark' %}
     {% set is_external = is_external_href(card.href) | trim %}
@@ -104,8 +99,8 @@
       <span class="FeaturedMenuCard__button FeaturedMenuCard__button--{{ card.button.variant }}">
         <span class="FeaturedMenuCard__button-label">
           <span>{{ card.button.text }}</span>
-          {% if card.button.icon and icon_map.get(card.button.icon) %}
-            <i class="bx {{ icon_map.get(card.button.icon) }}"></i>
+          {% if card.button.icon %}
+            <i class="bx {{ card.button.icon }}"></i>
           {% endif %}
         </span>
       </span>
@@ -138,11 +133,6 @@
      release blog post). Populated client-side (see the release-card script in
      layout.html). The button is static, from the card config. #}
   {% macro render_release_card_slot(card_section, size, parent_name, group_id) %}
-    {% set icon_map = {
-      'BiRightArrowAlt': 'bx-right-arrow-alt',
-      'BiLinkExternal': 'bx-link-external',
-      'BiChevronRight': 'bx-chevron-right',
-    } %}
     {% set button = card_section.cards.button %}
     <script type="application/json" class="release-card-config" data-group="{{ group_id }}">{"limit": {{ card_section.cards.limit }}}</script>
     {% for i in range(card_section.cards.limit) %}
@@ -160,8 +150,8 @@
         <span class="FeaturedMenuCard__button FeaturedMenuCard__button--{{ button.variant }}">
           <span class="FeaturedMenuCard__button-label">
             <span>{{ button.text }}</span>
-            {% if button.icon and icon_map.get(button.icon) %}
-              <i class="bx {{ icon_map.get(button.icon) }}"></i>
+            {% if button.icon %}
+              <i class="bx {{ button.icon }}"></i>
             {% endif %}
           </span>
         </span>
@@ -175,6 +165,9 @@
        {% if is_external %} rel="noopener noreferrer" target="_blank" {% endif %}
        onclick="sendCustomGAEvent('click', 'navbar_ux', 'navbar_button_click', '{{ parent_name }} > {{ item.name }}')">
       <span class="mega-menu-link__title">
+        {% if item.icon %}
+          <i class="bx {{ item.icon }} mega-menu-link__icon"></i>
+        {% endif %}
         <span class="mega-menu-link__name">{{ item.name }}</span>
         {% if item.pill and item.pill.text %}
           <span class="navbar-pill navbar-pill--{{ item.pill.variant }}">{{ item.pill.text }}</span>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -133,6 +133,42 @@
     {% endfor %}
   {% endmacro %}
 
+  {# Renders the dynamic "Latest Release" card (pennylane-app ReleaseMenuCard:
+     a primary-blue FeaturedMenuCard whose title/image/href come from the latest
+     release blog post). Populated client-side (see the release-card script in
+     layout.html). The button is static, from the card config. #}
+  {% macro render_release_card_slot(card_section, size, parent_name, group_id) %}
+    {% set icon_map = {
+      'BiRightArrowAlt': 'bx-right-arrow-alt',
+      'BiLinkExternal': 'bx-link-external',
+      'BiChevronRight': 'bx-chevron-right',
+    } %}
+    {% set button = card_section.cards.button %}
+    <script type="application/json" class="release-card-config" data-group="{{ group_id }}">{"limit": {{ card_section.cards.limit }}}</script>
+    {% for i in range(card_section.cards.limit) %}
+      <a class="mega-menu-card MenuCard MenuCard--dark FeaturedMenuCard FeaturedMenuCard--{{ size }} FeaturedMenuCard--dark FeaturedMenuCard--{{ card_section.cards.variant }} release-menu-card release-menu-card--loading"
+         data-release-card-group="{{ group_id }}" data-release-card-index="{{ i }}"
+         data-parent-name="{{ parent_name }}"
+         href="#" aria-hidden="true" tabindex="-1">
+        <svg class="MenuCard__border-svg" aria-hidden="true">
+          <rect class="MenuCard__border-rect" rx="5" pathLength="400"></rect>
+        </svg>
+        <div class="FeaturedMenuCard__content">
+          <h4 class="FeaturedMenuCard__title FeaturedMenuCard__title--clamp-4"></h4>
+        </div>
+        <div class="FeaturedMenuCard__image FeaturedMenuCard__image--full FeaturedMenuCard__image--placeholder release-menu-card__image" aria-hidden="true"></div>
+        <span class="FeaturedMenuCard__button FeaturedMenuCard__button--{{ button.variant }}">
+          <span class="FeaturedMenuCard__button-label">
+            <span>{{ button.text }}</span>
+            {% if button.icon and icon_map.get(button.icon) %}
+              <i class="bx {{ icon_map.get(button.icon) }}"></i>
+            {% endif %}
+          </span>
+        </span>
+      </a>
+    {% endfor %}
+  {% endmacro %}
+
   {% macro render_mega_menu_link(item, header, parent_name) %}
     {% set is_external = is_external_href(item.href) | trim %}
     <a class="mega-menu-link" href="{{ pathto(item.href, 1) }}"
@@ -198,14 +234,14 @@
               {% if card_section.type == 'featured' %}
                 {% set card_ns.total_card_columns = card_ns.total_card_columns + (card_section.cards | length) %}
                 {% set card_ns.has_cards = true %}
-              {% elif card_section.type == 'content' %}
+              {% elif card_section.type in ['content', 'release'] %}
                 {% set card_ns.total_card_columns = card_ns.total_card_columns + card_section.cards.limit %}
                 {% set card_ns.has_cards = true %}
               {% endif %}
             {% endfor %}
             {% if card_ns.has_cards %}
               <div class="navbar-mega-menu__cards-area" style="--menu-card-total-columns: {{ card_ns.total_card_columns }};">
-                {% for card_section in link.cardSections if card_section.type in ['featured', 'content'] %}
+                {% for card_section in link.cardSections if card_section.type in ['featured', 'content', 'release'] %}
                   {% set col_span = (card_section.cards | length) if card_section.type == 'featured' else card_section.cards.limit %}
                   <div class="navbar-mega-menu__card-section-header" style="grid-column: span {{ col_span }} / span {{ col_span }};">
                     <div class="mega-menu-section-header">
@@ -219,11 +255,13 @@
                     </div>
                   </div>
                 {% endfor %}
-                {% for card_section in link.cardSections if card_section.type in ['featured', 'content'] %}
+                {% for card_section in link.cardSections if card_section.type in ['featured', 'content', 'release'] %}
                   {% if card_section.type == 'featured' %}
                     {% for card in card_section.cards %}
                       {{ render_featured_card(card, 'desktop', link.name) }}
                     {% endfor %}
+                  {% elif card_section.type == 'release' %}
+                    {{ render_release_card_slot(card_section, 'desktop', link.name, 'd-' ~ (link.name | replace(' ', '_') | replace('&', 'and')) ~ '-' ~ loop.index0) }}
                   {% else %}
                     {{ render_content_card_slots(card_section, 'desktop', 'd-' ~ (link.name | replace(' ', '_') | replace('&', 'and')) ~ '-' ~ loop.index0) }}
                   {% endif %}
@@ -379,7 +417,7 @@
           {% endfor %}
         {% endfor %}
         {% if link.cardSections %}
-          {% for card_section in link.cardSections if card_section.type in ['featured', 'content'] %}
+          {% for card_section in link.cardSections if card_section.type in ['featured', 'content', 'release'] %}
             <div class="navbar-mega-menu__section">
               <div class="mega-menu-section-header">
                 <h3 class="mega-menu-section-header__title">{{ card_section.header }}</h3>
@@ -395,6 +433,8 @@
                   {% for card in card_section.cards %}
                     {{ render_featured_card(card, 'mobile', link.name) }}
                   {% endfor %}
+                {% elif card_section.type == 'release' %}
+                  {{ render_release_card_slot(card_section, 'mobile', link.name, 'm-' ~ (link.name | replace(' ', '_') | replace('&', 'and')) ~ '-' ~ loop.index0) }}
                 {% else %}
                   {{ render_content_card_slots(card_section, 'mobile', 'm-' ~ (link.name | replace(' ', '_') | replace('&', 'and')) ~ '-' ~ loop.index0) }}
                 {% endif %}

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -112,6 +112,27 @@
     </a>
   {% endmacro %}
 
+  {# Renders placeholder slots for a dynamic "content" card section. The query
+     config is embedded as JSON and the slots are populated client-side from the
+     PennyLane content API (see the content-cards script in layout.html). #}
+  {% macro render_content_card_slots(card_section, size, group_id) %}
+    <script type="application/json" class="content-cards-config" data-group="{{ group_id }}">{"limit": {{ card_section.cards.limit }}, "filters": {{ card_section.cards.filters | tojson }}, "fallbackImageSrc": {{ (card_section.cards.fallbackImageSrc or '') | tojson }}}</script>
+    {% for i in range(card_section.cards.limit) %}
+      <a class="mega-menu-card MenuCard MenuCard--light ContentMenuCard ContentMenuCard--{{ size }} content-menu-card content-menu-card--loading"
+         data-content-card-group="{{ group_id }}" data-content-card-index="{{ i }}"
+         href="#" aria-hidden="true" tabindex="-1">
+        <svg class="MenuCard__border-svg" aria-hidden="true">
+          <rect class="MenuCard__border-rect" rx="5" pathLength="400"></rect>
+        </svg>
+        <div class="ContentMenuCard__image ContentMenuCard__image--no-image"></div>
+        <div class="ContentMenuCard__content">
+          <h4 class="ContentMenuCard__title"></h4>
+          <p class="ContentMenuCard__description"></p>
+        </div>
+      </a>
+    {% endfor %}
+  {% endmacro %}
+
   {% macro render_mega_menu_link(item, header, parent_name) %}
     {% set is_external = is_external_href(item.href) | trim %}
     <a class="mega-menu-link" href="{{ pathto(item.href, 1) }}"
@@ -172,17 +193,21 @@
             {% endfor %}
           </div>
           {% if link.cardSections %}
-            {% set card_ns = namespace(total_card_columns=0, has_featured=false) %}
+            {% set card_ns = namespace(total_card_columns=0, has_cards=false) %}
             {% for card_section in link.cardSections %}
               {% if card_section.type == 'featured' %}
                 {% set card_ns.total_card_columns = card_ns.total_card_columns + (card_section.cards | length) %}
-                {% set card_ns.has_featured = true %}
+                {% set card_ns.has_cards = true %}
+              {% elif card_section.type == 'content' %}
+                {% set card_ns.total_card_columns = card_ns.total_card_columns + card_section.cards.limit %}
+                {% set card_ns.has_cards = true %}
               {% endif %}
             {% endfor %}
-            {% if card_ns.has_featured %}
+            {% if card_ns.has_cards %}
               <div class="navbar-mega-menu__cards-area" style="--menu-card-total-columns: {{ card_ns.total_card_columns }};">
-                {% for card_section in link.cardSections if card_section.type == 'featured' %}
-                  <div class="navbar-mega-menu__card-section-header" style="grid-column: span {{ card_section.cards | length }} / span {{ card_section.cards | length }};">
+                {% for card_section in link.cardSections if card_section.type in ['featured', 'content'] %}
+                  {% set col_span = (card_section.cards | length) if card_section.type == 'featured' else card_section.cards.limit %}
+                  <div class="navbar-mega-menu__card-section-header" style="grid-column: span {{ col_span }} / span {{ col_span }};">
                     <div class="mega-menu-section-header">
                       <h3 class="mega-menu-section-header__title">{{ card_section.header }}</h3>
                       {% if card_section.cta %}
@@ -194,10 +219,14 @@
                     </div>
                   </div>
                 {% endfor %}
-                {% for card_section in link.cardSections if card_section.type == 'featured' %}
-                  {% for card in card_section.cards %}
-                    {{ render_featured_card(card, 'desktop', link.name) }}
-                  {% endfor %}
+                {% for card_section in link.cardSections if card_section.type in ['featured', 'content'] %}
+                  {% if card_section.type == 'featured' %}
+                    {% for card in card_section.cards %}
+                      {{ render_featured_card(card, 'desktop', link.name) }}
+                    {% endfor %}
+                  {% else %}
+                    {{ render_content_card_slots(card_section, 'desktop', 'd-' ~ (link.name | replace(' ', '_') | replace('&', 'and')) ~ '-' ~ loop.index0) }}
+                  {% endif %}
                 {% endfor %}
               </div>
             {% endif %}
@@ -350,7 +379,7 @@
           {% endfor %}
         {% endfor %}
         {% if link.cardSections %}
-          {% for card_section in link.cardSections if card_section.type == 'featured' %}
+          {% for card_section in link.cardSections if card_section.type in ['featured', 'content'] %}
             <div class="navbar-mega-menu__section">
               <div class="mega-menu-section-header">
                 <h3 class="mega-menu-section-header__title">{{ card_section.header }}</h3>
@@ -362,9 +391,13 @@
                 {% endif %}
               </div>
               <div class="MobileMenu__cards">
-                {% for card in card_section.cards %}
-                  {{ render_featured_card(card, 'mobile', link.name) }}
-                {% endfor %}
+                {% if card_section.type == 'featured' %}
+                  {% for card in card_section.cards %}
+                    {{ render_featured_card(card, 'mobile', link.name) }}
+                  {% endfor %}
+                {% else %}
+                  {{ render_content_card_slots(card_section, 'mobile', 'm-' ~ (link.name | replace(' ', '_') | replace('&', 'and')) ~ '-' ~ loop.index0) }}
+                {% endif %}
               </div>
             </div>
           {% endfor %}

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -20,7 +20,7 @@
 
         <span>{{ name }}</span>
         {% if external %}
-          <i class='bx bx-arrow-out-up-right-square'></i> 
+          <i class='bx bx-link-external'></i> 
         {% elif dropdown %}
           <i class="bx bx-chevron-down"></i>
         {% endif %}
@@ -36,7 +36,7 @@
                   {{ link.name }}
                 {%- endif -%}
                 {% if link.external %}
-                  <i class='bx bx-arrow-out-up-right-square'></i> 
+                  <i class='bx bx-link-external'></i> 
                 {% endif %}
               </a>
             </li>
@@ -60,19 +60,90 @@
     </li>
   {% endmacro %}
 
+  {# Whether a link should open in a new tab (anything outside the pennylane.ai ecosystem). #}
+  {% macro is_external_href(href) %}{% if href and href.startswith('http') and not (href.startswith('https://pennylane.ai') or href.startswith('https://docs.pennylane.ai')) %}1{% endif %}{% endmacro %}
+
+  {% macro render_mega_menu_link(item, header, parent_name) %}
+    {% set is_external = is_external_href(item.href) | trim %}
+    <a class="mega-menu-link" href="{{ pathto(item.href, 1) }}"
+       {% if is_external %} rel="noopener noreferrer" target="_blank" {% endif %}
+       onclick="sendCustomGAEvent('click', 'navbar_ux', 'navbar_button_click', '{{ parent_name }} > {{ item.name }}')">
+      <span class="mega-menu-link__title">
+        <span class="mega-menu-link__name">{{ item.name }}</span>
+        {% if item.pill and item.pill.text %}
+          <span class="navbar-pill navbar-pill--{{ item.pill.variant }}">{{ item.pill.text }}</span>
+        {% endif %}
+        {% if is_external %}
+          <i class="bx bx-link-external mega-menu-link__external-icon"></i>
+        {% endif %}
+      </span>
+      {% if item.description %}
+        <p class="mega-menu-link__description">{{ item.description }}</p>
+      {% endif %}
+    </a>
+  {% endmacro %}
+
+  {% macro render_desktop_navbar_mega_item(link) %}
+    {% set ns = namespace(total_columns=0) %}
+    {% for link_section in link.linkSections %}{% set ns.total_columns = ns.total_columns + link_section.columns %}{% endfor %}
+    <li class="navbar-left-link desktop has-mega-menu">
+      <button class="dropdown-trigger" aria-label="open {{ link.name }} sub-menu" aria-expanded="false">
+        <span class="navbar-link__label">
+          <span>{{ link.name }}</span>
+          {% if link.pill and link.pill.text %}
+            <span class="navbar-pill navbar-pill--{{ link.pill.variant }}">{{ link.pill.text }}</span>
+          {% endif %}
+        </span>
+        <i class="bx bx-chevron-down"></i>
+      </button>
+      <div class="navbar-mega-menu desktop">
+        <div class="navbar-mega-menu__inner">
+          <div class="navbar-mega-menu__links-area" style="--menu-link-total-columns: {{ ns.total_columns }};">
+            {% for link_section in link.linkSections %}
+              <div class="navbar-mega-menu__link-section" style="grid-column: span {{ link_section.columns }} / span {{ link_section.columns }};">
+                {% for section in link_section.sections %}
+                  <div class="navbar-mega-menu__section">
+                    <div class="mega-menu-section-header">
+                      <h3 class="mega-menu-section-header__title">{{ section.header }}</h3>
+                      {% if section.cta %}
+                        <a class="mega-menu-section-header__cta" href="{{ pathto(section.cta.href, 1) }}" onclick="sendCustomGAEvent('click', 'navbar_ux', 'navbar_button_click', '{{ link.name }} > {{ section.cta.text }}')">
+                          <span>{{ section.cta.text }}</span>
+                          <i class="bx bx-chevron-right"></i>
+                        </a>
+                      {% endif %}
+                    </div>
+                    <ul class="mega-menu-section-links {% if link_section.columns > 1 %}mega-menu-section-links--multi-column{% endif %}" style="--link-section-columns: {{ link_section.columns }};">
+                      {% for item in section['items'] %}
+                        <li>{{ render_mega_menu_link(item, section.header, link.name) }}</li>
+                      {% endfor %}
+                    </ul>
+                  </div>
+                {% endfor %}
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </li>
+  {% endmacro %}
+
   <div class="navbar-links desktop">
     <ul class="navbar-left-links desktop">
       {% for link in theme_navbar_left_links %}
-        {{
-            render_desktop_navbar_left_link(
-              link.name,
-              link.href,
-              link.img,
-              link.img_width,
-              link.external,
-              link.dropdown
-            )
-        }}
+        {% if link.linkSections %}
+          {{ render_desktop_navbar_mega_item(link) }}
+        {% else %}
+          {{
+              render_desktop_navbar_left_link(
+                link.name,
+                link.href,
+                link.img,
+                link.img_width,
+                link.external,
+                link.dropdown
+              )
+          }}
+        {% endif %}
       {% endfor %}
     </ul>
     <ul class="navbar-right-links desktop">
@@ -111,7 +182,7 @@
           <div>
             <span>{{ name }}</span>
             {% if external %}
-              <i class='bx bx-arrow-out-up-right-square'></i> 
+              <i class='bx bx-link-external'></i> 
             {% endif %}
           </div>
           {% if dropdown %}
@@ -125,7 +196,7 @@
 
               <span>{{ name }}</span>
               {% if external %}
-                <i class='bx bx-arrow-out-up-right-square'></i> 
+                <i class='bx bx-link-external'></i> 
               {% endif %}
             </a>
           {% else %}
@@ -143,7 +214,7 @@
                     {{ name }}
                   {%- endif -%}
                   {% if external %}
-                    <i class='bx bx-arrow-out-up-right-square'></i> 
+                    <i class='bx bx-link-external'></i> 
                   {% endif %}
                 </a>
             </li>
@@ -155,7 +226,7 @@
                   {{ link.name }}
                 {%- endif -%}
                 {% if link.external %}
-                  <i class='bx bx-arrow-out-up-right-square'></i> 
+                  <i class='bx bx-link-external'></i> 
                 {% endif %}
               </a>
             </li>
@@ -164,6 +235,44 @@
       </div>
     </li>
   {% endmacro %}
+
+  {% macro render_mobile_navbar_mega(link) %}
+    <li class="navbar-link mobile">
+      <button class="navbar-link-heading mobile" onclick="toggleMobileNavbarLink(this)" aria-label="open {{ link.name }} sub-menu" aria-expanded="false">
+        <div>
+          <span>{{ link.name }}</span>
+          {% if link.pill and link.pill.text %}
+            <span class="navbar-pill navbar-pill--{{ link.pill.variant }}">{{ link.pill.text }}</span>
+          {% endif %}
+        </div>
+      <i class="bx bx-chevron-down"></i>
+    </button>
+    <div class="navbar-dropdown mobile">
+      <div class="mobile-mega-menu">
+        {% for link_section in link.linkSections %}
+          {% for section in link_section.sections %}
+            <div class="navbar-mega-menu__section">
+              <div class="mega-menu-section-header">
+                <h3 class="mega-menu-section-header__title">{{ section.header }}</h3>
+                {% if section.cta %}
+                  <a class="mega-menu-section-header__cta" href="{{ pathto(section.cta.href, 1) }}" onclick="sendCustomGAEvent('click', 'navbar_ux', 'navbar_button_click', '{{ link.name }} > {{ section.cta.text }}')">
+                    <span>{{ section.cta.text }}</span>
+                    <i class="bx bx-chevron-right"></i>
+                  </a>
+                {% endif %}
+              </div>
+              <ul class="mega-menu-section-links">
+                {% for item in section['items'] %}
+                  <li>{{ render_mega_menu_link(item, section.header, link.name) }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endfor %}
+        {% endfor %}
+      </div>
+    </div>
+  </li>
+{% endmacro %}
 
   {% macro render_mobile_navbar_button(name, href=None) %}
     {% if href %}
@@ -205,14 +314,18 @@
     {% endif %}
 
     {% for link in theme_navbar_left_links %}
-      {{
-          render_mobile_navbar_link(
-            link.name,
-            link.href,
-            link.external,
-            link.dropdown,
-          )
-      }}
+      {% if link.linkSections %}
+        {{ render_mobile_navbar_mega(link) }}
+      {% else %}
+        {{
+            render_mobile_navbar_link(
+              link.name,
+              link.href,
+              link.external,
+              link.dropdown,
+            )
+        }}
+      {% endif %}
     {% endfor %}
 
     {% for link in theme_navbar_right_links|selectattr("icon") %}

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -63,6 +63,55 @@
   {# Whether a link should open in a new tab (anything outside the pennylane.ai ecosystem). #}
   {% macro is_external_href(href) %}{% if href and href.startswith('http') and not (href.startswith('https://pennylane.ai') or href.startswith('https://docs.pennylane.ai')) %}1{% endif %}{% endmacro %}
 
+  {# Minimal markdown renderer: only converts **bold** segments, mirroring the
+     limited markdown used in pennylane-app's featured card descriptions. #}
+  {% macro render_markdown_bold(text) -%}
+    {%- for part in text.split('**') -%}
+      {%- if loop.index0 is odd -%}<strong>{{ part }}</strong>{%- else -%}{{ part }}{%- endif -%}
+    {%- endfor -%}
+  {%- endmacro %}
+
+  {# Renders a single featured navbar card (pennylane-app's FeaturedMenuCard).
+     size is 'desktop' or 'mobile'. #}
+  {% macro render_featured_card(card, size, parent_name) %}
+    {% set icon_map = {
+      'BiRightArrowAlt': 'bx-right-arrow-alt',
+      'BiLinkExternal': 'bx-link-external',
+      'BiChevronRight': 'bx-chevron-right',
+    } %}
+    {% set light_variants = ['white', 'soft-blue', 'confetti'] %}
+    {% set theme = 'light' if card.variant in light_variants else 'dark' %}
+    {% set is_external = is_external_href(card.href) | trim %}
+    <a class="mega-menu-card MenuCard MenuCard--{{ theme }} FeaturedMenuCard FeaturedMenuCard--{{ size }} FeaturedMenuCard--{{ theme }} FeaturedMenuCard--{{ card.variant }}"
+       href="{{ pathto(card.href, 1) }}"
+       {% if is_external %} rel="noopener noreferrer" target="_blank" {% endif %}
+       onclick="sendCustomGAEvent('click', 'navbar_ux', 'navbar_card_click', '{{ parent_name }} > {{ card.title }}')">
+      <svg class="MenuCard__border-svg" aria-hidden="true">
+        <rect class="MenuCard__border-rect" rx="5" pathLength="400"></rect>
+      </svg>
+      {% if card.pill and card.pill.text %}
+        <span class="navbar-pill navbar-pill--{{ card.pill.variant }}">{{ card.pill.text }}</span>
+      {% endif %}
+      <div class="FeaturedMenuCard__content">
+        <h4 class="FeaturedMenuCard__title FeaturedMenuCard__title--truncate">{{ card.title }}</h4>
+        {% if card.description %}
+          <div class="FeaturedMenuCard__description"><p>{{ render_markdown_bold(card.description) }}</p></div>
+        {% endif %}
+      </div>
+      {% if card.imageSrc %}
+        <img class="FeaturedMenuCard__image FeaturedMenuCard__image--{{ card.imageSize }}" src="{{ card.imageSrc }}" alt="{{ card.title }}">
+      {% endif %}
+      <span class="FeaturedMenuCard__button FeaturedMenuCard__button--{{ card.button.variant }}">
+        <span class="FeaturedMenuCard__button-label">
+          <span>{{ card.button.text }}</span>
+          {% if card.button.icon and icon_map.get(card.button.icon) %}
+            <i class="bx {{ icon_map.get(card.button.icon) }}"></i>
+          {% endif %}
+        </span>
+      </span>
+    </a>
+  {% endmacro %}
+
   {% macro render_mega_menu_link(item, header, parent_name) %}
     {% set is_external = is_external_href(item.href) | trim %}
     <a class="mega-menu-link" href="{{ pathto(item.href, 1) }}"
@@ -122,6 +171,37 @@
               </div>
             {% endfor %}
           </div>
+          {% if link.cardSections %}
+            {% set card_ns = namespace(total_card_columns=0, has_featured=false) %}
+            {% for card_section in link.cardSections %}
+              {% if card_section.type == 'featured' %}
+                {% set card_ns.total_card_columns = card_ns.total_card_columns + (card_section.cards | length) %}
+                {% set card_ns.has_featured = true %}
+              {% endif %}
+            {% endfor %}
+            {% if card_ns.has_featured %}
+              <div class="navbar-mega-menu__cards-area" style="--menu-card-total-columns: {{ card_ns.total_card_columns }};">
+                {% for card_section in link.cardSections if card_section.type == 'featured' %}
+                  <div class="navbar-mega-menu__card-section-header" style="grid-column: span {{ card_section.cards | length }} / span {{ card_section.cards | length }};">
+                    <div class="mega-menu-section-header">
+                      <h3 class="mega-menu-section-header__title">{{ card_section.header }}</h3>
+                      {% if card_section.cta %}
+                        <a class="mega-menu-section-header__cta" href="{{ pathto(card_section.cta.href, 1) }}" onclick="sendCustomGAEvent('click', 'navbar_ux', 'navbar_button_click', '{{ link.name }} > {{ card_section.cta.text }}')">
+                          <span>{{ card_section.cta.text }}</span>
+                          <i class="bx bx-chevron-right"></i>
+                        </a>
+                      {% endif %}
+                    </div>
+                  </div>
+                {% endfor %}
+                {% for card_section in link.cardSections if card_section.type == 'featured' %}
+                  {% for card in card_section.cards %}
+                    {{ render_featured_card(card, 'desktop', link.name) }}
+                  {% endfor %}
+                {% endfor %}
+              </div>
+            {% endif %}
+          {% endif %}
         </div>
       </div>
     </li>
@@ -269,6 +349,26 @@
             </div>
           {% endfor %}
         {% endfor %}
+        {% if link.cardSections %}
+          {% for card_section in link.cardSections if card_section.type == 'featured' %}
+            <div class="navbar-mega-menu__section">
+              <div class="mega-menu-section-header">
+                <h3 class="mega-menu-section-header__title">{{ card_section.header }}</h3>
+                {% if card_section.cta %}
+                  <a class="mega-menu-section-header__cta" href="{{ pathto(card_section.cta.href, 1) }}" onclick="sendCustomGAEvent('click', 'navbar_ux', 'navbar_button_click', '{{ link.name }} > {{ card_section.cta.text }}')">
+                    <span>{{ card_section.cta.text }}</span>
+                    <i class="bx bx-chevron-right"></i>
+                  </a>
+                {% endif %}
+              </div>
+              <div class="MobileMenu__cards">
+                {% for card in card_section.cards %}
+                  {{ render_featured_card(card, 'mobile', link.name) }}
+                {% endfor %}
+              </div>
+            </div>
+          {% endfor %}
+        {% endif %}
       </div>
     </div>
   </li>

--- a/xanadu_sphinx_theme/header.html
+++ b/xanadu_sphinx_theme/header.html
@@ -71,6 +71,20 @@
     {%- endfor -%}
   {%- endmacro %}
 
+  {# Renders a navbar status pill (pennylane-app's NavbarPill). Optional
+     startDate/expiryDate (ISO strings, e.g. '2026-05-01') gate the pill's
+     visibility: a dated pill is emitted hidden and revealed client-side only
+     while within the [startDate, expiryDate) window (see the navbar-pill script
+     in layout.html), since Sphinx docs render statically at build time. #}
+  {% macro render_navbar_pill(pill) -%}
+    {%- if pill and pill.text -%}
+      <span class="navbar-pill navbar-pill--{{ pill.variant }}"
+        {%- if pill.startDate %} data-pill-start-date="{{ pill.startDate }}"{% endif %}
+        {%- if pill.expiryDate %} data-pill-expiry-date="{{ pill.expiryDate }}"{% endif %}
+        {%- if pill.startDate or pill.expiryDate %} hidden{% endif %}>{{ pill.text }}</span>
+    {%- endif -%}
+  {%- endmacro %}
+
   {# Renders a single featured navbar card (pennylane-app's FeaturedMenuCard).
      size is 'desktop' or 'mobile'. #}
   {% macro render_featured_card(card, size, parent_name) %}
@@ -84,9 +98,7 @@
       <svg class="MenuCard__border-svg" aria-hidden="true">
         <rect class="MenuCard__border-rect" rx="5" pathLength="400"></rect>
       </svg>
-      {% if card.pill and card.pill.text %}
-        <span class="navbar-pill navbar-pill--{{ card.pill.variant }}">{{ card.pill.text }}</span>
-      {% endif %}
+      {{ render_navbar_pill(card.pill) }}
       <div class="FeaturedMenuCard__content">
         <h4 class="FeaturedMenuCard__title FeaturedMenuCard__title--truncate">{{ card.title }}</h4>
         {% if card.description %}
@@ -163,9 +175,7 @@
           <i class="bx {{ item.icon }} mega-menu-link__icon"></i>
         {% endif %}
         <span class="mega-menu-link__name">{{ item.name }}</span>
-        {% if item.pill and item.pill.text %}
-          <span class="navbar-pill navbar-pill--{{ item.pill.variant }}">{{ item.pill.text }}</span>
-        {% endif %}
+        {{ render_navbar_pill(item.pill) }}
         {% if is_external %}
           <i class="bx bx-link-external mega-menu-link__external-icon"></i>
         {% endif %}
@@ -183,9 +193,7 @@
       <button class="dropdown-trigger" aria-label="open {{ link.name }} sub-menu" aria-expanded="false">
         <span class="navbar-link__label">
           <span>{{ link.name }}</span>
-          {% if link.pill and link.pill.text %}
-            <span class="navbar-pill navbar-pill--{{ link.pill.variant }}">{{ link.pill.text }}</span>
-          {% endif %}
+          {{ render_navbar_pill(link.pill) }}
         </span>
         <i class="bx bx-chevron-down"></i>
       </button>
@@ -379,9 +387,7 @@
       <button class="navbar-link-heading mobile" onclick="toggleMobileNavbarLink(this)" aria-label="open {{ link.name }} sub-menu" aria-expanded="false">
         <div>
           <span>{{ link.name }}</span>
-          {% if link.pill and link.pill.text %}
-            <span class="navbar-pill navbar-pill--{{ link.pill.variant }}">{{ link.pill.text }}</span>
-          {% endif %}
+          {{ render_navbar_pill(link.pill) }}
         </div>
       <i class="bx bx-chevron-down"></i>
     </button>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -355,11 +355,6 @@
     document.querySelectorAll("h1 ~ .section").forEach((element) => {
       element.classList.remove("section");
     });
-    const OverlayScrollbarsInit = (window.OverlayScrollbarsGlobal && window.OverlayScrollbarsGlobal.OverlayScrollbars) || window.OverlayScrollbars;
-    const nanoElement = document.querySelector('.nano');
-    if (typeof OverlayScrollbarsInit === 'function' && nanoElement !== null) {
-      OverlayScrollbarsInit(nanoElement, {});
-    }
   </script>
 
   <script type="text/javascript">

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -998,5 +998,116 @@
     })();
   </script>
 
+  <!-- Populates the navbar "Latest Release" card from the PennyLane API. -->
+  <script type="text/javascript">
+    (function () {
+      var GRAPHQL_ENDPOINT = "https://cloud.pennylane.ai/graphql";
+      var BLOG_BASE_URL = "https://pennylane.ai";
+      var FALLBACK_IMAGE_SRC =
+        "https://assets.cloud.pennylane.ai/pennylane_website/pages/blog/typewriter.png";
+
+      var RELEASE_QUERY = [
+        "query LatestReleaseBlogPost {",
+        "  blogPostForLatestRelease {",
+        "    title",
+        "    slug",
+        "    features { thumbnail }",
+        "  }",
+        "}"
+      ].join("\n");
+
+      // Mirrors shared-utilities `mapLatestReleaseBlogPostToNavbarCard`.
+      function mapReleasePost(post) {
+        if (!post) {
+          return null;
+        }
+        var features = post.features || [];
+        var lastThumbnail =
+          features.length > 0 ? features[features.length - 1].thumbnail : "";
+        return {
+          title: post.title || "",
+          href: BLOG_BASE_URL + "/blog/" + post.slug,
+          imageSrc: lastThumbnail || FALLBACK_IMAGE_SRC
+        };
+      }
+
+      var releaseRequest = null;
+
+      function fetchRelease() {
+        if (releaseRequest) {
+          return releaseRequest;
+        }
+        releaseRequest = fetch(GRAPHQL_ENDPOINT, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ query: RELEASE_QUERY })
+        })
+          .then(function (response) { return response.json(); })
+          .then(function (json) {
+            return mapReleasePost(
+              json && json.data && json.data.blogPostForLatestRelease
+            );
+          });
+        return releaseRequest;
+      }
+
+      function fillCard(card, item) {
+        var titleEl = card.querySelector(".FeaturedMenuCard__title");
+        var imageEl = card.querySelector(".release-menu-card__image");
+
+        if (titleEl) { titleEl.textContent = item.title; }
+
+        if (imageEl && item.imageSrc) {
+          var img = document.createElement("img");
+          img.className =
+            "FeaturedMenuCard__image FeaturedMenuCard__image--full release-menu-card__image";
+          img.src = item.imageSrc;
+          img.alt = item.title || "";
+          imageEl.parentNode.replaceChild(img, imageEl);
+        }
+
+        card.setAttribute("href", item.href || "#");
+        card.removeAttribute("aria-hidden");
+        card.removeAttribute("tabindex");
+        card.classList.remove("release-menu-card--loading");
+      }
+
+      function markEmpty(card) {
+        card.classList.remove("release-menu-card--loading");
+        card.classList.add("release-menu-card--empty");
+      }
+
+      function init() {
+        var cards = document.querySelectorAll(".release-menu-card");
+        if (cards.length === 0) {
+          return;
+        }
+
+        fetchRelease()
+          .then(function (item) {
+            for (var i = 0; i < cards.length; i++) {
+              if (item) {
+                fillCard(cards[i], item);
+              } else {
+                markEmpty(cards[i]);
+              }
+            }
+          })
+          .catch(function (error) {
+            console.error("Failed to load navbar release card", error);
+            for (var j = 0; j < cards.length; j++) {
+              markEmpty(cards[j]);
+            }
+          });
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+      } else {
+        init();
+      }
+    })();
+  </script>
+
   {% include "footer.html" %}
 {%- endblock %}

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -592,6 +592,77 @@
         overlay.classList.toggle("open", megaOpen);
       };
 
+      // Resolves the three animation layers of a mega-menu nav item.
+      const megaParts = (link) => {
+        const container = link.querySelector(".navbar-mega-menu");
+        if (container === null) return null;
+        return {
+          container: container,
+          resize: container.querySelector(".navbar-mega-menu__resize"),
+          inner: container.querySelector(".navbar-mega-menu__inner"),
+        };
+      };
+
+      // Clears inline styles left over from a height-swap so the item can
+      // open/close via the default CSS grid animation.
+      const resetMega = (link) => {
+        const parts = megaParts(link);
+        if (parts === null) return;
+        parts.container.style.transition = "";
+        if (parts.resize !== null) {
+          parts.resize.style.transition = "";
+          parts.resize.style.height = "";
+        }
+      };
+
+      // Switches directly from one open mega menu to another by resizing the
+      // height to fit the new content, instead of closing then reopening.
+      // Mirrors pennylane-app's useMegaMenuAnimation height-swap FLIP: the old
+      // panel is snapped shut with no animation, and the new panel is shown
+      // instantly at the old height before transitioning to its own height.
+      const switchMega = (oldLink, newLink) => {
+        const o = megaParts(oldLink);
+        const n = megaParts(newLink);
+        if (o === null || n === null || o.resize === null || n.resize === null) {
+          if (o !== null) oldLink.classList.remove("open");
+          newLink.classList.add("open");
+          return;
+        }
+
+        const oldHeight = o.resize.offsetHeight;
+
+        // Snap the previous menu closed with no animation.
+        o.container.style.transition = "none";
+        o.resize.style.transition = "none";
+        oldLink.classList.remove("open");
+        o.resize.style.height = "";
+        void o.container.offsetHeight; // commit reflow
+        o.container.style.transition = "";
+        o.resize.style.transition = "";
+        const oldTrigger = oldLink.querySelector(".dropdown-trigger");
+        if (oldTrigger !== null) setAriaAttributes(oldTrigger, false);
+
+        // Reveal the new menu instantly (no slide), measure its natural height,
+        // pin it to the old height, then transition to the new height.
+        n.container.style.transition = "none";
+        n.resize.style.transition = "none";
+        newLink.classList.add("open");
+        n.resize.style.height = "";
+        const newHeight = n.inner.offsetHeight;
+        n.resize.style.height = oldHeight + "px";
+        void n.container.offsetHeight; // commit reflow at the old height
+        n.container.style.transition = "";
+        n.resize.style.transition = "";
+        n.resize.style.height = newHeight + "px";
+
+        const onEnd = (event) => {
+          if (event.target !== n.resize || event.propertyName !== "height") return;
+          n.resize.style.height = "";
+          n.resize.removeEventListener("transitionend", onEnd);
+        };
+        n.resize.addEventListener("transitionend", onEnd);
+      };
+
       // Clicking the backdrop closes any open dropdown.
       if (overlay !== null) {
         overlay.addEventListener("click", function() {
@@ -615,14 +686,35 @@
 
           // Expands the current dropdown and closes other dropdowns.
           const expandDropdown = () => {
+            // Find a mega menu that is already open (there is at most one).
+            let prevOpen = null;
             Object.entries(timers).forEach(([j, timer]) => {
               clearTimeout(timer.timeout);
-              if (parseInt(i) !== parseInt(j)) {
-                timer.link.classList.remove("open");
-                setAriaAttributes(timer.trigger, false);
+              if (parseInt(i) !== parseInt(j) && timer.link.classList.contains("open")) {
+                prevOpen = timer.link;
               }
             });
-            link.classList.add("open");
+
+            const switching =
+              prevOpen !== null &&
+              prevOpen.classList.contains("has-mega-menu") &&
+              link.classList.contains("has-mega-menu");
+
+            if (switching) {
+              // Resize from the open menu's height to this one's, no close+open.
+              switchMega(prevOpen, link);
+            } else {
+              Object.values(timers).forEach((timer) => {
+                if (timer.link !== link) {
+                  timer.link.classList.remove("open");
+                  setAriaAttributes(timer.trigger, false);
+                  resetMega(timer.link);
+                }
+              });
+              resetMega(link);
+              link.classList.add("open");
+            }
+
             setAriaAttributes(trigger, true);
             window.updateMegaMenuOverlay();
           };

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -717,6 +717,9 @@
 
             setAriaAttributes(trigger, true);
             window.updateMegaMenuOverlay();
+            if (typeof window.loadDynamicNavbarCardsInContainer === "function") {
+              window.loadDynamicNavbarCardsInContainer(link);
+            }
           };
 
           // Closes the current dropdown after the given delay.
@@ -860,6 +863,9 @@
         item.classList.add("open");
         if (dropdown !== null) expandMobileDropdown(dropdown);
         setAriaAttributes(button, true);
+        if (typeof window.loadDynamicNavbarCardsInContainer === "function") {
+          window.loadDynamicNavbarCardsInContainer(item);
+        }
       };
 
       if (container === null) {
@@ -1149,6 +1155,7 @@
       }
 
       var requestCache = {};
+      var loadedContentGroups = Object.create(null);
 
       function fetchItems(input, limit) {
         var cacheKey = JSON.stringify(input) + "|" + limit;
@@ -1203,6 +1210,11 @@
 
       function populateGroup(config) {
         var groupId = config.group;
+        if (loadedContentGroups[groupId]) {
+          return;
+        }
+        loadedContentGroups[groupId] = true;
+
         var cards = document.querySelectorAll(
           '.content-menu-card[data-content-card-group="' + groupId + '"]'
         );
@@ -1231,8 +1243,11 @@
           });
       }
 
-      function init() {
-        var configScripts = document.querySelectorAll("script.content-cards-config");
+      function loadContentCardsInContainer(container) {
+        if (!container) {
+          return;
+        }
+        var configScripts = container.querySelectorAll("script.content-cards-config");
         for (var i = 0; i < configScripts.length; i++) {
           var script = configScripts[i];
           var config;
@@ -1247,11 +1262,7 @@
         }
       }
 
-      if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", init);
-      } else {
-        init();
-      }
+      window.loadContentCardsInContainer = loadContentCardsInContainer;
     })();
   </script>
 
@@ -1308,34 +1319,121 @@
         return releaseRequest;
       }
 
-      function fillCard(card, item) {
-        var titleEl = card.querySelector(".FeaturedMenuCard__title");
-        var imageEl = card.querySelector(".release-menu-card__image");
+      function getReleaseCardConfig(groupId) {
+        var script = document.querySelector(
+          'script.release-card-config[data-group="' + groupId + '"]'
+        );
+        if (script === null) {
+          return null;
+        }
+        try {
+          return JSON.parse(script.textContent);
+        } catch (error) {
+          console.error("Invalid navbar release-card config", error);
+          return null;
+        }
+      }
 
-        if (titleEl) { titleEl.textContent = item.title; }
+      function createFilledReleaseCard(card, item, config) {
+        var size = card.classList.contains("ReleaseMenuCardSkeleton--mobile")
+          ? "mobile"
+          : "desktop";
+        var variant = (config && config.variant) || "primary-blue";
+        var button = (config && config.button) || {};
+        var parentName = card.getAttribute("data-parent-name") || "";
 
-        if (imageEl && item.imageSrc) {
+        var link = document.createElement("a");
+        link.className =
+          "mega-menu-card MenuCard MenuCard--dark FeaturedMenuCard FeaturedMenuCard--"
+          + size + " FeaturedMenuCard--dark FeaturedMenuCard--" + variant
+          + " release-menu-card";
+        link.href = item.href || "#";
+        if (item.href && /^https?:\/\//.test(item.href)) {
+          link.rel = "noopener noreferrer";
+          link.target = "_blank";
+        }
+        link.addEventListener("click", function () {
+          sendCustomGAEvent(
+            "click",
+            "navbar_ux",
+            "navbar_card_click",
+            parentName + " > " + (item.title || "")
+          );
+        });
+
+        var svgNS = "http://www.w3.org/2000/svg";
+        var svg = document.createElementNS(svgNS, "svg");
+        svg.setAttribute("class", "MenuCard__border-svg");
+        svg.setAttribute("aria-hidden", "true");
+        var rect = document.createElementNS(svgNS, "rect");
+        rect.setAttribute("class", "MenuCard__border-rect");
+        rect.setAttribute("rx", "5");
+        rect.setAttribute("pathLength", "400");
+        svg.appendChild(rect);
+        link.appendChild(svg);
+
+        var content = document.createElement("div");
+        content.className = "FeaturedMenuCard__content";
+        var titleEl = document.createElement("h4");
+        titleEl.className = "FeaturedMenuCard__title FeaturedMenuCard__title--clamp-4";
+        titleEl.textContent = item.title || "";
+        content.appendChild(titleEl);
+        link.appendChild(content);
+
+        if (item.imageSrc) {
           var img = document.createElement("img");
           img.className =
             "FeaturedMenuCard__image FeaturedMenuCard__image--full release-menu-card__image";
           img.src = item.imageSrc;
           img.alt = item.title || "";
-          imageEl.parentNode.replaceChild(img, imageEl);
+          link.appendChild(img);
+        } else {
+          var placeholder = document.createElement("div");
+          placeholder.className =
+            "FeaturedMenuCard__image FeaturedMenuCard__image--full FeaturedMenuCard__image--placeholder release-menu-card__image";
+          placeholder.setAttribute("aria-hidden", "true");
+          link.appendChild(placeholder);
         }
 
-        card.setAttribute("href", item.href || "#");
-        card.removeAttribute("aria-hidden");
-        card.removeAttribute("tabindex");
-        card.classList.remove("release-menu-card--loading");
+        var btn = document.createElement("span");
+        btn.className =
+          "FeaturedMenuCard__button FeaturedMenuCard__button--"
+          + (button.variant || "secondary");
+        var btnLabel = document.createElement("span");
+        btnLabel.className = "FeaturedMenuCard__button-label";
+        var btnText = document.createElement("span");
+        btnText.textContent = button.text || "";
+        btnLabel.appendChild(btnText);
+        if (button.icon) {
+          var icon = document.createElement("i");
+          icon.className = "bx " + button.icon;
+          btnLabel.appendChild(icon);
+        }
+        btn.appendChild(btnLabel);
+        link.appendChild(btn);
+
+        return link;
+      }
+
+      function fillCard(card, item) {
+        var groupId = card.getAttribute("data-release-card-group");
+        var config = getReleaseCardConfig(groupId);
+        var filled = createFilledReleaseCard(card, item, config);
+        card.parentNode.replaceChild(filled, card);
       }
 
       function markEmpty(card) {
-        card.classList.remove("release-menu-card--loading");
-        card.classList.add("release-menu-card--empty");
+        var empty = document.createElement("div");
+        empty.className = "mega-menu-card release-menu-card release-menu-card--empty";
+        empty.setAttribute("aria-hidden", "true");
+        card.parentNode.replaceChild(empty, card);
       }
 
-      function init() {
-        var cards = document.querySelectorAll(".release-menu-card");
+      function loadReleaseCardsInContainer(container) {
+        if (!container) {
+          return;
+        }
+        var cards = container.querySelectorAll(".release-menu-card.release-menu-card--loading");
         if (cards.length === 0) {
           return;
         }
@@ -1358,11 +1456,13 @@
           });
       }
 
-      if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", init);
-      } else {
-        init();
-      }
+      window.loadReleaseCardsInContainer = loadReleaseCardsInContainer;
+      window.loadDynamicNavbarCardsInContainer = function (container) {
+        if (typeof window.loadContentCardsInContainer === "function") {
+          window.loadContentCardsInContainer(container);
+        }
+        loadReleaseCardsInContainer(container);
+      };
     })();
   </script>
 

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -20,8 +20,8 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500&display=swap">
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css">
-  <!-- Box Icons -->
-  <link href="https://cdn.boxicons.com/fonts/basic/boxicons.min.css" rel="stylesheet">
+  <!-- Box Icons (regular icons pinned to v2 to match pennylane-app; brands stay on v3) -->
+  <link href="https://cdn.jsdelivr.net/npm/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet">
   <link href="https://cdn.boxicons.com/fonts/brands/boxicons-brands.min.css" rel="stylesheet">
   <!-- Bootstrap core CSS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
@@ -586,7 +586,7 @@
       const timers = {};
       const navbar_left_links = document.querySelectorAll(".navbar-left-link");
       navbar_left_links.forEach((link, i) => {
-        const dropdown = link.querySelector(".navbar-dropdown");
+        const dropdown = link.querySelector(".navbar-dropdown, .navbar-mega-menu");
         // trigger is the element that controls the opening/closing of the dropdown.
         // will be <a> tag for links, or <button> otherwise
         const trigger = link.querySelector(".dropdown-trigger");
@@ -669,16 +669,10 @@
     }
 
     function getDropdownHeight(dropdown) {
-      const dropdown_list = dropdown.querySelector("ul");
-      const dropdown_list_items = dropdown_list.querySelectorAll("li");
-      const dropdown_list_gap = getIntStyleProperty(dropdown_list, "gap");
-
-      let dropdown_list_height = -dropdown_list_gap;
-      for (const list_item of dropdown_list_items) {
-        dropdown_list_height += getIntStyleProperty(list_item, "height");
-        dropdown_list_height += dropdown_list_gap
-      }
-      return dropdown_list_height + "px";
+      // scrollHeight reflects the full rendered content height (including the
+      // dropdown's padding and any multi-line descriptions / section headers),
+      // even while the container is collapsed to height: 0.
+      return dropdown.scrollHeight + "px";
     }
 
     function toggleMobileNavbarLink(button) {

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -1179,6 +1179,42 @@
     });
   </script>
 
+  <!-- Reveals navbar pills gated by start/expiry dates (mirrors pennylane-app's
+       NavbarPill). Dated pills render hidden; show them only within the
+       [startDate, expiryDate) window, evaluated against the visitor's clock. -->
+  <script type="text/javascript">
+    (function () {
+      function updateNavbarPills() {
+        var now = new Date();
+        var pills = document.querySelectorAll(
+          ".navbar-pill[data-pill-start-date], .navbar-pill[data-pill-expiry-date]"
+        );
+        pills.forEach(function (pill) {
+          var startDate = pill.getAttribute("data-pill-start-date");
+          var expiryDate = pill.getAttribute("data-pill-expiry-date");
+          var visible = true;
+          if (startDate && now < new Date(startDate)) {
+            visible = false;
+          }
+          if (expiryDate && now >= new Date(expiryDate)) {
+            visible = false;
+          }
+          if (visible) {
+            pill.removeAttribute("hidden");
+          } else {
+            pill.remove();
+          }
+        });
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", updateNavbarPills);
+      } else {
+        updateNavbarPills();
+      }
+    })();
+  </script>
+
   <!-- Populates the navbar "content" cards from the PennyLane content API. -->
   <script type="text/javascript">
     (function () {

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -577,6 +577,52 @@
     function toggleAriaAttributes(button) {
       setAriaAttributes(button, button.getAttribute("aria-expanded") === "false");
     }
+
+    // Removes closed navbar panels from the tab order (mirrors pennylane-app's
+    // MegaMenu `inert` when collapsed and mobile FocusTrap scope).
+    window.setNavbarMenuInertState = function() {
+      document.querySelectorAll(".desktop.navbar-left-link").forEach(function(link) {
+        const isOpen = link.classList.contains("open");
+        const megaMenu = link.querySelector(".navbar-mega-menu");
+        const dropdown = link.querySelector(".navbar-dropdown.desktop");
+        if (megaMenu !== null) {
+          megaMenu.toggleAttribute("inert", !isOpen);
+        }
+        if (dropdown !== null) {
+          dropdown.toggleAttribute("inert", !isOpen);
+        }
+      });
+
+      const mobileMenu = document.querySelector(".mobile.navbar-links");
+      if (mobileMenu !== null) {
+        mobileMenu.toggleAttribute("inert", !mobileMenu.classList.contains("open"));
+      }
+
+      document.querySelectorAll(".mobile.navbar-link").forEach(function(item) {
+        const dropdown = item.querySelector(".mobile.navbar-dropdown");
+        if (dropdown !== null) {
+          dropdown.toggleAttribute("inert", !item.classList.contains("open"));
+        }
+      });
+    };
+
+    window.getNavbarKeyboardFocusable = function(container) {
+      if (container === null) {
+        return [];
+      }
+      return Array.from(container.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )).filter(function(element) {
+        return element.closest("[inert]") === null
+          && element.getAttribute("aria-hidden") !== "true";
+      });
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", window.setNavbarMenuInertState);
+    } else {
+      window.setNavbarMenuInertState();
+    }
   </script>
 
   <!-- Delays the closing of dropdowns on the LHS of the navigation bar. -->
@@ -672,6 +718,9 @@
             if (trigger !== null) setAriaAttributes(trigger, false);
           });
           window.updateMegaMenuOverlay();
+          if (typeof window.setNavbarMenuInertState === "function") {
+            window.setNavbarMenuInertState();
+          }
         });
       }
 
@@ -720,6 +769,9 @@
             if (typeof window.loadDynamicNavbarCardsInContainer === "function") {
               window.loadDynamicNavbarCardsInContainer(link);
             }
+            if (typeof window.setNavbarMenuInertState === "function") {
+              window.setNavbarMenuInertState();
+            }
           };
 
           // Closes the current dropdown after the given delay.
@@ -728,6 +780,9 @@
               link.classList.remove("open");
               setAriaAttributes(trigger, false);
               window.updateMegaMenuOverlay();
+              if (typeof window.setNavbarMenuInertState === "function") {
+                window.setNavbarMenuInertState();
+              }
             }, delay);
           };
 
@@ -756,6 +811,9 @@
           }
         });
         window.updateMegaMenuOverlay();
+        if (typeof window.setNavbarMenuInertState === "function") {
+          window.setNavbarMenuInertState();
+        }
       });
 
       // Close every open desktop dropdown/mega menu (used on breakpoint change).
@@ -769,6 +827,9 @@
           }
         });
         window.updateMegaMenuOverlay();
+        if (typeof window.setNavbarMenuInertState === "function") {
+          window.setNavbarMenuInertState();
+        }
       };
     })();
   </script>
@@ -801,6 +862,9 @@
         const hidden_elements = document.querySelectorAll(".container-wrapper, footer");
         for (const element of hidden_elements) {
           element.setAttribute("aria-hidden", hidden.toString());
+        }
+        if (typeof window.setNavbarMenuInertState === "function") {
+          window.setNavbarMenuInertState();
         }
       }
     }
@@ -865,6 +929,9 @@
         setAriaAttributes(button, true);
         if (typeof window.loadDynamicNavbarCardsInContainer === "function") {
           window.loadDynamicNavbarCardsInContainer(item);
+        }
+        if (typeof window.setNavbarMenuInertState === "function") {
+          window.setNavbarMenuInertState();
         }
       };
 
@@ -932,9 +999,15 @@
             if (event.propertyName !== "height") return;
             dropdown.removeEventListener("transitionend", onCollapseEnd);
             item.classList.remove("open");
+            if (typeof window.setNavbarMenuInertState === "function") {
+              window.setNavbarMenuInertState();
+            }
           });
         } else {
           item.classList.remove("open");
+          if (typeof window.setNavbarMenuInertState === "function") {
+            window.setNavbarMenuInertState();
+          }
         }
         return;
       }
@@ -949,6 +1022,9 @@
         openItem.classList.remove("open");
         if (openButton !== null) setAriaAttributes(openButton, false);
       });
+      if (typeof window.setNavbarMenuInertState === "function") {
+        window.setNavbarMenuInertState();
+      }
 
       glideMobileAccordionToTop(item, button, dropdown);
     }
@@ -993,6 +1069,9 @@
           dropdown.style.height = "";
         });
       });
+      if (typeof window.setNavbarMenuInertState === "function") {
+        window.setNavbarMenuInertState();
+      }
     };
   </script>
 
@@ -1044,12 +1123,18 @@
         // Close an open navbar dropdown on desktop.
         const navbar_left_links = document.querySelectorAll(".navbar-left-link");
         for (const link of navbar_left_links) {
-          const button = link.querySelector("button");
+          const trigger = link.querySelector(".dropdown-trigger");
           if (link.classList.contains("open")) {
             link.classList.remove("open");
-            setAriaAttributes(button, true);
+            if (trigger !== null) {
+              setAriaAttributes(trigger, false);
+              trigger.focus();
+            }
             if (typeof window.updateMegaMenuOverlay === "function") {
               window.updateMegaMenuOverlay();
+            }
+            if (typeof window.setNavbarMenuInertState === "function") {
+              window.setNavbarMenuInertState();
             }
             return;
           }
@@ -1058,36 +1143,38 @@
     });
   </script>
 
-  <!-- Trap focus in the navbar dropdown on mobile if it is expanded. -->
+  <!-- Trap focus in the mobile menu while it is open. -->
   <script type="text/javascript">
-    // Using ``keyup`` would cause the last element to be quickly "skipped".
-    document.addEventListener('keydown', function(event) {
-      // The keycode of TAB is 9.
-      if (event.keyCode == 9) {
-        // Do nothing if the navbar dropdown is collapsed on mobile.
-        const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
-        if (mobileMenuButton === null || !mobileMenuButton.classList.contains("open")) {
-          return;
-        }
+    document.addEventListener("keydown", function(event) {
+      if (event.key !== "Tab") {
+        return;
+      }
 
-        const links = document.querySelectorAll(".mobile.navbar-links a");
-        const bot = links[links.length - 1];
-        const top = document.querySelector(".mobile.navbar-menu button");
+      const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
+      const mobileMenu = document.querySelector(".mobile.navbar-links");
+      if (mobileMenuButton === null || mobileMenu === null
+          || !mobileMenuButton.classList.contains("open")) {
+        return;
+      }
 
-        // Do nothing if there is a missing focus element.
-        if (top === null || bot === undefined) {
-          return;
-        }
+      const menuFocusables = window.getNavbarKeyboardFocusable
+        ? window.getNavbarKeyboardFocusable(mobileMenu)
+        : [];
+      const focusables = [mobileMenuButton].concat(menuFocusables);
+      if (focusables.length === 0) {
+        return;
+      }
 
-        // Wrap the focus to the top or bottom element if needed. The direction
-        // of the wrapping depends on whether TAB or SHIFT + TAB is pressed.
-        if (!event.shiftKey && document.activeElement === bot) {
-          top.focus();
-          event.preventDefault();
-        } else if (event.shiftKey && document.activeElement === top) {
-          bot.focus();
-          event.preventDefault();
-        }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+
+      if (!event.shiftKey && active === last) {
+        first.focus();
+        event.preventDefault();
+      } else if (event.shiftKey && active === first) {
+        last.focus();
+        event.preventDefault();
       }
     });
   </script>

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -392,8 +392,8 @@
 
   <script type="text/javascript">
     if (document.querySelector(".current")) {
-      var target = document.querySelector(".current");
-      var rect = target.getBoundingClientRect();
+      const target = document.querySelector(".current");
+      const rect = target.getBoundingClientRect();
       if (rect.bottom > window.innerHeight) {
           const nanoElement = document.querySelector(".nano");
           const currentElement = document.querySelector(".current");
@@ -435,18 +435,18 @@
       anchor.appendChild(target);
     }
 
-    var downloadNote = document.querySelectorAll(".sphx-glr-download-link-note.admonition.note");
+    const downloadNote = document.querySelectorAll(".sphx-glr-download-link-note.admonition.note");
     if (downloadNote.length >= 1) {
       const tutorialType = document.querySelector("#tutorial-type");
       const downloadLinks = document.querySelectorAll(".sphx-glr-download .reference.download");
       if (tutorialType !== null && downloadLinks.length >= 2) {
-        var tutorialUrlArray = tutorialType.textContent.split('/');
+        const tutorialUrlArray = tutorialType.textContent.split('/');
 
         if (tutorialUrlArray[0] == "demos") {
           tutorialUrlArray[0] = "demonstrations";
         }
 
-        var githubLink = "https://github.com/" + "{{ theme_github_repo }}" + "/blob/master/" + tutorialUrlArray.join("/") + ".py",
+        const githubLink = "https://github.com/" + "{{ theme_github_repo }}" + "/blob/master/" + tutorialUrlArray.join("/") + ".py",
             pythonLink = downloadLinks[0].href,
             notebookLink = downloadLinks[1].href;
 
@@ -489,12 +489,12 @@
 
     <script type="text/javascript">
       function makeUL(urls, text) {
-          var list = document.createElement('ul');
+          const list = document.createElement('ul');
 
           for (var i = 0; i < urls.length; i++) {
-              var item = document.createElement('li');
-              var a = document.createElement('a');
-              var linkText = document.createTextNode(text[i]);
+              const item = document.createElement('li');
+              const a = document.createElement('a');
+              const linkText = document.createTextNode(text[i]);
               a.appendChild(linkText);
               a.href = urls[i];
               item.appendChild(a);
@@ -1185,13 +1185,13 @@
   <script type="text/javascript">
     (function () {
       function updateNavbarPills() {
-        var now = new Date();
-        var pills = document.querySelectorAll(
+        const now = new Date();
+        const pills = document.querySelectorAll(
           ".navbar-pill[data-pill-start-date], .navbar-pill[data-pill-expiry-date]"
         );
         pills.forEach(function (pill) {
-          var startDate = pill.getAttribute("data-pill-start-date");
-          var expiryDate = pill.getAttribute("data-pill-expiry-date");
+          const startDate = pill.getAttribute("data-pill-start-date");
+          const expiryDate = pill.getAttribute("data-pill-expiry-date");
           var visible = true;
           if (startDate && now < new Date(startDate)) {
             visible = false;
@@ -1215,13 +1215,18 @@
     })();
   </script>
 
+  <!-- Shared PennyLane GraphQL endpoint, reused by the navbar content scripts below. -->
+  <script type="text/javascript">
+    // TODO: Change to production endpoint before merging feature branch
+    window.PENNYLANE_GRAPHQL_ENDPOINT = "https://dev.cloud.pennylane.ai/graphql";
+  </script>
+
   <!-- Populates the navbar "content" cards from the PennyLane content API. -->
   <script type="text/javascript">
     (function () {
-      // TODO: Change to production endpoint before merging feature branch
-      var GRAPHQL_ENDPOINT = "https://dev.cloud.pennylane.ai/graphql";
+      const GRAPHQL_ENDPOINT = window.PENNYLANE_GRAPHQL_ENDPOINT;
 
-      var SEARCH_QUERY = [
+      const SEARCH_QUERY = [
         "query SearchQuery($input: SearchInput!, $page: PageInput) {",
         "  search(input: $input, page: $page) {",
         "    totalItems",
@@ -1234,7 +1239,7 @@
 
       // Mirrors shared-utilities `buildSearchInput` for the subset of filters the
       // navbar content cards use.
-      var SORT_MAP = {
+      const SORT_MAP = {
         "title": [{ field: "title", desc: false }],
         "-title": [{ field: "title", desc: true }],
         "publication_date": [{ field: "publishedAt", desc: true }],
@@ -1243,9 +1248,9 @@
 
       function buildSearchInput(filters) {
         filters = filters || {};
-        var contentType = (filters.contentType || "").toUpperCase();
-        var categories = filters.categories || [];
-        var specificFiltersByType = {
+        const contentType = (filters.contentType || "").toUpperCase();
+        const categories = filters.categories || [];
+        const specificFiltersByType = {
           BLOG: { blogFilters: { categories: categories } },
           CHALLENGE: { challengeFilters: { categories: categories, difficulties: filters.difficulties || [] } },
           CODEBOOK_TOPIC: { codebookTopicFilters: { moduleCategories: filters.moduleCategories || [], moduleTitles: filters.moduleTitles || [] } },
@@ -1255,13 +1260,13 @@
           DOC: { docFilters: assign({ projects: filters.projects || [] }, filters.version ? { version: filters.version } : {}) }
         };
 
-        var input = {
+        const input = {
           contentTypes: contentType ? [contentType] : null,
           genericFilters: { yearsOfPublication: filters.years },
           sorts: (filters.sort && SORT_MAP[filters.sort]) || null
         };
 
-        var specificFilters = specificFiltersByType[contentType];
+        const specificFilters = specificFiltersByType[contentType];
         if (specificFilters) {
           input.specificFilters = specificFilters;
         }
@@ -1269,7 +1274,7 @@
       }
 
       function assign(target, source) {
-        for (var key in source) {
+        for (const key in source) {
           if (Object.prototype.hasOwnProperty.call(source, key)) {
             target[key] = source[key];
           }
@@ -1277,15 +1282,15 @@
         return target;
       }
 
-      var requestCache = {};
-      var loadedContentGroups = Object.create(null);
+      const requestCache = {};
+      const loadedContentGroups = Object.create(null);
 
       function fetchItems(input, limit) {
-        var cacheKey = JSON.stringify(input) + "|" + limit;
+        const cacheKey = JSON.stringify(input) + "|" + limit;
         if (requestCache[cacheKey]) {
           return requestCache[cacheKey];
         }
-        var promise = fetch(GRAPHQL_ENDPOINT, {
+        const promise = fetch(GRAPHQL_ENDPOINT, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -1302,15 +1307,15 @@
       }
 
       function fillCard(card, item, fallbackImageSrc) {
-        var imageEl = card.querySelector(".ContentMenuCard__image");
-        var titleEl = card.querySelector(".ContentMenuCard__title");
-        var descEl = card.querySelector(".ContentMenuCard__description");
+        const imageEl = card.querySelector(".ContentMenuCard__image");
+        const titleEl = card.querySelector(".ContentMenuCard__title");
+        const descEl = card.querySelector(".ContentMenuCard__description");
 
-        var src = (item.thumbnail && item.thumbnail.length > 0)
+        const src = (item.thumbnail && item.thumbnail.length > 0)
           ? item.thumbnail
           : (fallbackImageSrc || "");
         if (src && imageEl) {
-          var img = document.createElement("img");
+          const img = document.createElement("img");
           img.className = "ContentMenuCard__image";
           img.src = src;
           img.alt = item.title || "";
@@ -1332,25 +1337,25 @@
       }
 
       function populateGroup(config) {
-        var groupId = config.group;
+        const groupId = config.group;
         if (loadedContentGroups[groupId]) {
           return;
         }
         loadedContentGroups[groupId] = true;
 
-        var cards = document.querySelectorAll(
+        const cards = document.querySelectorAll(
           '.content-menu-card[data-content-card-group="' + groupId + '"]'
         );
         if (cards.length === 0) {
           return;
         }
 
-        var input = buildSearchInput(config.filters);
+        const input = buildSearchInput(config.filters);
         fetchItems(input, config.limit)
           .then(function (items) {
             for (var i = 0; i < cards.length; i++) {
-              var card = cards[i];
-              var index = parseInt(card.getAttribute("data-content-card-index"), 10) || 0;
+              const card = cards[i];
+              const index = parseInt(card.getAttribute("data-content-card-index"), 10) || 0;
               if (items[index]) {
                 fillCard(card, items[index], config.fallbackImageSrc);
               } else {
@@ -1370,9 +1375,9 @@
         if (!container) {
           return;
         }
-        var configScripts = container.querySelectorAll("script.content-cards-config");
+        const configScripts = container.querySelectorAll("script.content-cards-config");
         for (var i = 0; i < configScripts.length; i++) {
-          var script = configScripts[i];
+          const script = configScripts[i];
           var config;
           try {
             config = JSON.parse(script.textContent);
@@ -1392,12 +1397,12 @@
   <!-- Populates the navbar "Latest Release" card from the PennyLane API. -->
   <script type="text/javascript">
     (function () {
-      var GRAPHQL_ENDPOINT = "https://cloud.pennylane.ai/graphql";
-      var BLOG_BASE_URL = "https://pennylane.ai";
-      var FALLBACK_IMAGE_SRC =
+      const GRAPHQL_ENDPOINT = window.PENNYLANE_GRAPHQL_ENDPOINT;
+      const BLOG_BASE_URL = "https://pennylane.ai";
+      const FALLBACK_IMAGE_SRC =
         "https://assets.cloud.pennylane.ai/pennylane_website/pages/blog/typewriter.png";
 
-      var RELEASE_QUERY = [
+      const RELEASE_QUERY = [
         "query LatestReleaseBlogPost {",
         "  blogPostForLatestRelease {",
         "    title",
@@ -1412,8 +1417,8 @@
         if (!post) {
           return null;
         }
-        var features = post.features || [];
-        var lastThumbnail =
+        const features = post.features || [];
+        const lastThumbnail =
           features.length > 0 ? features[features.length - 1].thumbnail : "";
         return {
           title: post.title || "",
@@ -1443,7 +1448,7 @@
       }
 
       function getReleaseCardConfig(groupId) {
-        var script = document.querySelector(
+        const script = document.querySelector(
           'script.release-card-config[data-group="' + groupId + '"]'
         );
         if (script === null) {
@@ -1458,14 +1463,14 @@
       }
 
       function createFilledReleaseCard(card, item, config) {
-        var size = card.classList.contains("ReleaseMenuCardSkeleton--mobile")
+        const size = card.classList.contains("ReleaseMenuCardSkeleton--mobile")
           ? "mobile"
           : "desktop";
-        var variant = (config && config.variant) || "primary-blue";
-        var button = (config && config.button) || {};
-        var parentName = card.getAttribute("data-parent-name") || "";
+        const variant = (config && config.variant) || "primary-blue";
+        const button = (config && config.button) || {};
+        const parentName = card.getAttribute("data-parent-name") || "";
 
-        var link = document.createElement("a");
+        const link = document.createElement("a");
         link.className =
           "mega-menu-card MenuCard MenuCard--dark FeaturedMenuCard FeaturedMenuCard--"
           + size + " FeaturedMenuCard--dark FeaturedMenuCard--" + variant
@@ -1484,51 +1489,51 @@
           );
         });
 
-        var svgNS = "http://www.w3.org/2000/svg";
-        var svg = document.createElementNS(svgNS, "svg");
+        const svgNS = "http://www.w3.org/2000/svg";
+        const svg = document.createElementNS(svgNS, "svg");
         svg.setAttribute("class", "MenuCard__border-svg");
         svg.setAttribute("aria-hidden", "true");
-        var rect = document.createElementNS(svgNS, "rect");
+        const rect = document.createElementNS(svgNS, "rect");
         rect.setAttribute("class", "MenuCard__border-rect");
         rect.setAttribute("rx", "5");
         rect.setAttribute("pathLength", "400");
         svg.appendChild(rect);
         link.appendChild(svg);
 
-        var content = document.createElement("div");
+        const content = document.createElement("div");
         content.className = "FeaturedMenuCard__content";
-        var titleEl = document.createElement("h4");
+        const titleEl = document.createElement("h4");
         titleEl.className = "FeaturedMenuCard__title FeaturedMenuCard__title--clamp-4";
         titleEl.textContent = item.title || "";
         content.appendChild(titleEl);
         link.appendChild(content);
 
         if (item.imageSrc) {
-          var img = document.createElement("img");
+          const img = document.createElement("img");
           img.className =
             "FeaturedMenuCard__image FeaturedMenuCard__image--full release-menu-card__image";
           img.src = item.imageSrc;
           img.alt = item.title || "";
           link.appendChild(img);
         } else {
-          var placeholder = document.createElement("div");
+          const placeholder = document.createElement("div");
           placeholder.className =
             "FeaturedMenuCard__image FeaturedMenuCard__image--full FeaturedMenuCard__image--placeholder release-menu-card__image";
           placeholder.setAttribute("aria-hidden", "true");
           link.appendChild(placeholder);
         }
 
-        var btn = document.createElement("span");
+        const btn = document.createElement("span");
         btn.className =
           "FeaturedMenuCard__button FeaturedMenuCard__button--"
           + (button.variant || "secondary");
-        var btnLabel = document.createElement("span");
+        const btnLabel = document.createElement("span");
         btnLabel.className = "FeaturedMenuCard__button-label";
-        var btnText = document.createElement("span");
+        const btnText = document.createElement("span");
         btnText.textContent = button.text || "";
         btnLabel.appendChild(btnText);
         if (button.icon) {
-          var icon = document.createElement("i");
+          const icon = document.createElement("i");
           icon.className = "bx " + button.icon;
           btnLabel.appendChild(icon);
         }
@@ -1539,14 +1544,14 @@
       }
 
       function fillCard(card, item) {
-        var groupId = card.getAttribute("data-release-card-group");
-        var config = getReleaseCardConfig(groupId);
-        var filled = createFilledReleaseCard(card, item, config);
+        const groupId = card.getAttribute("data-release-card-group");
+        const config = getReleaseCardConfig(groupId);
+        const filled = createFilledReleaseCard(card, item, config);
         card.parentNode.replaceChild(filled, card);
       }
 
       function markEmpty(card) {
-        var empty = document.createElement("div");
+        const empty = document.createElement("div");
         empty.className = "mega-menu-card release-menu-card release-menu-card--empty";
         empty.setAttribute("aria-hidden", "true");
         card.parentNode.replaceChild(empty, card);
@@ -1556,7 +1561,7 @@
         if (!container) {
           return;
         }
-        var cards = container.querySelectorAll(".release-menu-card.release-menu-card--loading");
+        const cards = container.querySelectorAll(".release-menu-card.release-menu-card--loading");
         if (cards.length === 0) {
           return;
         }

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -329,7 +329,7 @@
     });
   </script>
   <!-- Overlay Scrollbars -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/overlayscrollbars.cjs.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/2.11.4/browser/overlayscrollbars.browser.es6.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Syntax Highlighting -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.10/highlight.min.js"></script>
   <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
@@ -355,7 +355,11 @@
     document.querySelectorAll("h1 ~ .section").forEach((element) => {
       element.classList.remove("section");
     });
-    OverlayScrollbars(document.querySelector('.nano'), {});
+    const OverlayScrollbarsInit = (window.OverlayScrollbarsGlobal && window.OverlayScrollbarsGlobal.OverlayScrollbars) || window.OverlayScrollbars;
+    const nanoElement = document.querySelector('.nano');
+    if (typeof OverlayScrollbarsInit === 'function' && nanoElement !== null) {
+      OverlayScrollbarsInit(nanoElement, {});
+    }
   </script>
 
   <script type="text/javascript">
@@ -584,6 +588,27 @@
   <script type="text/javascript">
     (function() {
       const timers = {};
+      const overlay = document.querySelector(".navbar-overlay");
+
+      // Shows the dimmed backdrop only while a desktop mega menu is open.
+      window.updateMegaMenuOverlay = function() {
+        if (overlay === null) return;
+        const megaOpen = document.querySelector(".desktop.navbar-left-link.has-mega-menu.open") !== null;
+        overlay.classList.toggle("open", megaOpen);
+      };
+
+      // Clicking the backdrop closes any open dropdown.
+      if (overlay !== null) {
+        overlay.addEventListener("click", function() {
+          document.querySelectorAll(".navbar-left-link.open").forEach((link) => {
+            link.classList.remove("open");
+            const trigger = link.querySelector(".dropdown-trigger");
+            if (trigger !== null) setAriaAttributes(trigger, false);
+          });
+          window.updateMegaMenuOverlay();
+        });
+      }
+
       const navbar_left_links = document.querySelectorAll(".navbar-left-link");
       navbar_left_links.forEach((link, i) => {
         const dropdown = link.querySelector(".navbar-dropdown, .navbar-mega-menu");
@@ -604,6 +629,7 @@
             });
             link.classList.add("open");
             setAriaAttributes(trigger, true);
+            window.updateMegaMenuOverlay();
           };
 
           // Closes the current dropdown after the given delay.
@@ -611,6 +637,7 @@
             timers[i].timeout = setTimeout(function(){
               link.classList.remove("open");
               setAriaAttributes(trigger, false);
+              window.updateMegaMenuOverlay();
             }, delay);
           };
 
@@ -623,10 +650,22 @@
             }
           };
 
-          link.addEventListener("mouseenter", expandDropdown);
-          link.addEventListener("mouseleave", collapseDropdown);
+          // Mega menu opens/closes on click only (no hover).
           link.addEventListener("click", toggleDropdown);
         }
+      });
+
+      // Close any open dropdown when clicking outside of the navbar links.
+      document.addEventListener("click", function(event) {
+        if (event.target.closest(".navbar-left-link") !== null) return;
+        Object.values(timers).forEach((timer) => {
+          clearTimeout(timer.timeout);
+          if (timer.link.classList.contains("open")) {
+            timer.link.classList.remove("open");
+            setAriaAttributes(timer.trigger, false);
+          }
+        });
+        window.updateMegaMenuOverlay();
       });
     })();
   </script>
@@ -651,6 +690,9 @@
         dropdown.classList.toggle("open");
         button.classList.toggle("open");
         toggleAriaAttributes(button);
+
+        // Lock background scroll while the mobile menu is open.
+        document.body.classList.toggle("mobile-menu-open", button.classList.contains("open"));
 
         const hidden = button.getAttribute("aria-expanded") === "true";
         const hidden_elements = document.querySelectorAll(".container-wrapper, footer");
@@ -715,6 +757,9 @@
           if (link.classList.contains("open")) {
             link.classList.remove("open");
             setAriaAttributes(button, true);
+            if (typeof window.updateMegaMenuOverlay === "function") {
+              window.updateMegaMenuOverlay();
+            }
             return;
           }
         }

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -829,5 +829,174 @@
     });
   </script>
 
+  <!-- Populates the navbar "content" cards from the PennyLane content API. -->
+  <script type="text/javascript">
+    (function () {
+      // TODO: Change to production endpoint before merging feature branch
+      var GRAPHQL_ENDPOINT = "https://dev.cloud.pennylane.ai/graphql";
+
+      var SEARCH_QUERY = [
+        "query SearchQuery($input: SearchInput!, $page: PageInput) {",
+        "  search(input: $input, page: $page) {",
+        "    totalItems",
+        "    items {",
+        "      ... on Content { id slug type title description link thumbnail }",
+        "    }",
+        "  }",
+        "}"
+      ].join("\n");
+
+      // Mirrors shared-utilities `buildSearchInput` for the subset of filters the
+      // navbar content cards use.
+      var SORT_MAP = {
+        "title": [{ field: "title", desc: false }],
+        "-title": [{ field: "title", desc: true }],
+        "publication_date": [{ field: "publishedAt", desc: true }],
+        "-publication_date": [{ field: "publishedAt", desc: false }]
+      };
+
+      function buildSearchInput(filters) {
+        filters = filters || {};
+        var contentType = (filters.contentType || "").toUpperCase();
+        var categories = filters.categories || [];
+        var specificFiltersByType = {
+          BLOG: { blogFilters: { categories: categories } },
+          CHALLENGE: { challengeFilters: { categories: categories, difficulties: filters.difficulties || [] } },
+          CODEBOOK_TOPIC: { codebookTopicFilters: { moduleCategories: filters.moduleCategories || [], moduleTitles: filters.moduleTitles || [] } },
+          COMPILATION: { compilationFilters: assign({ categories: categories }, filters.basedOnPapers ? { basedOnPapers: true } : {}) },
+          DATASET_FAMILY: { datasetFamilyFilters: assign({ categories: categories }, filters.basedOnPapers ? { basedOnPapers: true } : {}) },
+          DEMO: { demoFilters: assign({ categories: categories }, filters.basedOnPapers ? { basedOnPapers: true } : {}) },
+          DOC: { docFilters: assign({ projects: filters.projects || [] }, filters.version ? { version: filters.version } : {}) }
+        };
+
+        var input = {
+          contentTypes: contentType ? [contentType] : null,
+          genericFilters: { yearsOfPublication: filters.years },
+          sorts: (filters.sort && SORT_MAP[filters.sort]) || null
+        };
+
+        var specificFilters = specificFiltersByType[contentType];
+        if (specificFilters) {
+          input.specificFilters = specificFilters;
+        }
+        return input;
+      }
+
+      function assign(target, source) {
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+          }
+        }
+        return target;
+      }
+
+      var requestCache = {};
+
+      function fetchItems(input, limit) {
+        var cacheKey = JSON.stringify(input) + "|" + limit;
+        if (requestCache[cacheKey]) {
+          return requestCache[cacheKey];
+        }
+        var promise = fetch(GRAPHQL_ENDPOINT, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            query: SEARCH_QUERY,
+            variables: { input: input, page: { limit: limit, offset: 0 } }
+          })
+        })
+          .then(function (response) { return response.json(); })
+          .then(function (json) {
+            return (json && json.data && json.data.search && json.data.search.items) || [];
+          });
+        requestCache[cacheKey] = promise;
+        return promise;
+      }
+
+      function fillCard(card, item, fallbackImageSrc) {
+        var imageEl = card.querySelector(".ContentMenuCard__image");
+        var titleEl = card.querySelector(".ContentMenuCard__title");
+        var descEl = card.querySelector(".ContentMenuCard__description");
+
+        var src = (item.thumbnail && item.thumbnail.length > 0)
+          ? item.thumbnail
+          : (fallbackImageSrc || "");
+        if (src && imageEl) {
+          var img = document.createElement("img");
+          img.className = "ContentMenuCard__image";
+          img.src = src;
+          img.alt = item.title || "";
+          imageEl.parentNode.replaceChild(img, imageEl);
+        }
+
+        if (titleEl) { titleEl.textContent = item.title || ""; }
+        if (descEl) { descEl.textContent = item.description || ""; }
+
+        card.setAttribute("href", item.link || "#");
+        card.removeAttribute("aria-hidden");
+        card.removeAttribute("tabindex");
+        card.classList.remove("content-menu-card--loading");
+      }
+
+      function markEmpty(card) {
+        card.classList.remove("content-menu-card--loading");
+        card.classList.add("content-menu-card--empty");
+      }
+
+      function populateGroup(config) {
+        var groupId = config.group;
+        var cards = document.querySelectorAll(
+          '.content-menu-card[data-content-card-group="' + groupId + '"]'
+        );
+        if (cards.length === 0) {
+          return;
+        }
+
+        var input = buildSearchInput(config.filters);
+        fetchItems(input, config.limit)
+          .then(function (items) {
+            for (var i = 0; i < cards.length; i++) {
+              var card = cards[i];
+              var index = parseInt(card.getAttribute("data-content-card-index"), 10) || 0;
+              if (items[index]) {
+                fillCard(card, items[index], config.fallbackImageSrc);
+              } else {
+                markEmpty(card);
+              }
+            }
+          })
+          .catch(function (error) {
+            console.error("Failed to load navbar content cards", error);
+            for (var j = 0; j < cards.length; j++) {
+              markEmpty(cards[j]);
+            }
+          });
+      }
+
+      function init() {
+        var configScripts = document.querySelectorAll("script.content-cards-config");
+        for (var i = 0; i < configScripts.length; i++) {
+          var script = configScripts[i];
+          var config;
+          try {
+            config = JSON.parse(script.textContent);
+          } catch (error) {
+            console.error("Invalid navbar content-cards config", error);
+            continue;
+          }
+          config.group = script.getAttribute("data-group");
+          populateGroup(config);
+        }
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+      } else {
+        init();
+      }
+    })();
+  </script>
+
   {% include "footer.html" %}
 {%- endblock %}

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -754,6 +754,19 @@
         });
         window.updateMegaMenuOverlay();
       });
+
+      // Close every open desktop dropdown/mega menu (used on breakpoint change).
+      window.closeAllDesktopMenus = function() {
+        Object.values(timers).forEach((timer) => {
+          clearTimeout(timer.timeout);
+          if (timer.link.classList.contains("open")) {
+            timer.link.classList.remove("open");
+            if (timer.trigger !== null) setAriaAttributes(timer.trigger, false);
+            resetMega(timer.link);
+          }
+        });
+        window.updateMegaMenuOverlay();
+      };
     })();
   </script>
 
@@ -933,6 +946,72 @@
 
       glideMobileAccordionToTop(item, button, dropdown);
     }
+
+    // Snap every open mobile menu/accordion shut (used on breakpoint change).
+    window.closeAllMobileMenus = function() {
+      const mobileMenu = getMobileScrollContainer();
+      const mobileMenuButton = document.querySelector(".mobile.navbar-menu button");
+
+      document.querySelectorAll(".mobile.navbar-link.open").forEach((item) => {
+        const button = item.querySelector(".mobile.navbar-link-heading");
+        const dropdown = item.querySelector(".mobile.navbar-dropdown");
+        if (dropdown !== null) {
+          dropdown.style.transition = "none";
+          dropdown.style.height = "0px";
+        }
+        item.classList.remove("open");
+        if (button !== null && button.getAttribute("aria-expanded") === "true") {
+          setAriaAttributes(button, false);
+        }
+      });
+
+      if (mobileMenu !== null) {
+        mobileMenu.classList.remove("open");
+        mobileMenu.style.paddingBottom = "";
+        mobileMenu.scrollTop = 0;
+      }
+
+      if (mobileMenuButton !== null && mobileMenuButton.classList.contains("open")) {
+        mobileMenuButton.classList.remove("open");
+        setAriaAttributes(mobileMenuButton, false);
+      }
+
+      document.body.classList.remove("mobile-menu-open");
+      document.querySelectorAll(".container-wrapper, footer").forEach((element) => {
+        element.setAttribute("aria-hidden", "false");
+      });
+
+      requestAnimationFrame(function() {
+        document.querySelectorAll(".mobile.navbar-dropdown").forEach((dropdown) => {
+          dropdown.style.transition = "";
+          dropdown.style.height = "";
+        });
+      });
+    };
+  </script>
+
+  <!-- Close open menus when crossing the mobile/desktop navbar breakpoint. -->
+  <script type="text/javascript">
+    (function() {
+      const NAVBAR_DESKTOP_BREAKPOINT = 1340;
+      const mediaQuery = window.matchMedia(
+        "(min-width: " + NAVBAR_DESKTOP_BREAKPOINT + "px)"
+      );
+
+      mediaQuery.addEventListener("change", function(event) {
+        if (event.matches) {
+          // mobile -> desktop
+          if (typeof window.closeAllMobileMenus === "function") {
+            window.closeAllMobileMenus();
+          }
+        } else {
+          // desktop -> mobile
+          if (typeof window.closeAllDesktopMenus === "function") {
+            window.closeAllDesktopMenus();
+          }
+        }
+      });
+    })();
   </script>
 
   <!-- Collapses the most specific menu when ESC is pressed. -->

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -710,19 +710,47 @@
       return parseInt(style.getPropertyValue(property), 10);
     }
 
-    function getDropdownHeight(dropdown) {
-      // scrollHeight reflects the full rendered content height (including the
-      // dropdown's padding and any multi-line descriptions / section headers),
-      // even while the container is collapsed to height: 0.
-      return dropdown.scrollHeight + "px";
+    // Expands the dropdown: animates from 0 to the measured content height, then
+    // switches to height:auto so the dropdown keeps responding to its content
+    // (e.g. when the section columns reflow on resize) instead of staying pinned
+    // to a stale fixed height.
+    function expandMobileDropdown(dropdown) {
+      dropdown.style.height = "auto";
+      const target = dropdown.offsetHeight;
+      dropdown.style.height = "0px";
+      // Force a reflow so the browser registers the 0px start before animating.
+      void dropdown.offsetHeight;
+      dropdown.style.height = target + "px";
+
+      const onTransitionEnd = (event) => {
+        if (event.propertyName !== "height") return;
+        dropdown.removeEventListener("transitionend", onTransitionEnd);
+        // Only release to auto if the dropdown is still open.
+        if (dropdown.parentElement.classList.contains("open")) {
+          dropdown.style.height = "auto";
+        }
+      };
+      dropdown.addEventListener("transitionend", onTransitionEnd);
+    }
+
+    // Collapses the dropdown: pins the current (possibly auto) height to an
+    // explicit pixel value so the transition back to 0 animates smoothly.
+    function collapseMobileDropdown(dropdown) {
+      dropdown.style.height = dropdown.scrollHeight + "px";
+      void dropdown.offsetHeight;
+      dropdown.style.height = "0px";
     }
 
     function toggleMobileNavbarLink(button) {
       const item = button.parentElement;
       const dropdown = item.querySelector(".mobile.navbar-dropdown");
       if (dropdown !== null) {
-        const hidden = button.getAttribute("aria-expanded") === "true";
-        dropdown.style.height = hidden ? "0px" : getDropdownHeight(dropdown);
+        const isOpen = button.getAttribute("aria-expanded") === "true";
+        if (isOpen) {
+          collapseMobileDropdown(dropdown);
+        } else {
+          expandMobileDropdown(dropdown);
+        }
       }
       item.classList.toggle("open");
       toggleAriaAttributes(button);

--- a/xanadu_sphinx_theme/layout.html
+++ b/xanadu_sphinx_theme/layout.html
@@ -828,19 +828,110 @@
       dropdown.style.height = "0px";
     }
 
+    // Resolves the scrollable mobile menu container.
+    function getMobileScrollContainer() {
+      return document.querySelector(".mobile.navbar-links");
+    }
+
+    // Glides the tapped accordion button to the top of the scrolling menu so it
+    // pins right below the navbar, then expands its panel. Mirrors pennylane-app's
+    // useMobileMenuAnimation scroll-to-pin behaviour: the button is eased to the
+    // top (re-measured each frame so a simultaneously collapsing panel can't throw
+    // it off), with extra bottom padding reserved so it can always reach the top.
+    function glideMobileAccordionToTop(item, button, dropdown) {
+      const container = getMobileScrollContainer();
+
+      const expand = () => {
+        // Apply .open before measuring so dropdown padding (py-4) is included
+        // in the expand height animation.
+        item.classList.add("open");
+        if (dropdown !== null) expandMobileDropdown(dropdown);
+        setAriaAttributes(button, true);
+      };
+
+      if (container === null) {
+        expand();
+        return;
+      }
+
+      const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+      const buttonViewportTop = () =>
+        button.getBoundingClientRect().top - container.getBoundingClientRect().top;
+
+      // Reserve room below so the button can reach the top even while collapsed.
+      container.style.paddingBottom = container.clientHeight + "px";
+
+      const expandAndSettle = () => {
+        container.scrollTop += buttonViewportTop();
+        expand();
+        // After the expand transition, trim the reserved padding while keeping
+        // the button pinned (leave just enough room if the content is short).
+        window.setTimeout(() => {
+          const target = container.scrollTop + buttonViewportTop();
+          container.style.paddingBottom = "";
+          const maxScroll = container.scrollHeight - container.clientHeight;
+          const deficit = Math.max(0, Math.ceil(target - maxScroll));
+          if (deficit > 0) container.style.paddingBottom = deficit + "px";
+          container.scrollTop = target;
+        }, 380);
+      };
+
+      const start = Math.max(0, buttonViewportTop());
+      if (start <= 1) {
+        expandAndSettle();
+        return;
+      }
+
+      // Duration scales with travel distance (clamped) so it feels consistent.
+      const duration = Math.min(700, 320 + start * 0.45);
+      const startTime = performance.now();
+      const step = (now) => {
+        const t = Math.min((now - startTime) / duration, 1);
+        const desired = start * (1 - easeOutCubic(t));
+        container.scrollTop += buttonViewportTop() - desired;
+        if (t < 1) {
+          requestAnimationFrame(step);
+        } else {
+          expandAndSettle();
+        }
+      };
+      requestAnimationFrame(step);
+    }
+
     function toggleMobileNavbarLink(button) {
       const item = button.parentElement;
       const dropdown = item.querySelector(".mobile.navbar-dropdown");
-      if (dropdown !== null) {
-        const isOpen = button.getAttribute("aria-expanded") === "true";
-        if (isOpen) {
+      const isOpen = button.getAttribute("aria-expanded") === "true";
+
+      // Closing the open accordion: collapse in place while keeping the sticky
+      // toggle styled until the height transition finishes.
+      if (isOpen) {
+        setAriaAttributes(button, false);
+        if (dropdown !== null) {
           collapseMobileDropdown(dropdown);
+          dropdown.addEventListener("transitionend", function onCollapseEnd(event) {
+            if (event.propertyName !== "height") return;
+            dropdown.removeEventListener("transitionend", onCollapseEnd);
+            item.classList.remove("open");
+          });
         } else {
-          expandMobileDropdown(dropdown);
+          item.classList.remove("open");
         }
+        return;
       }
-      item.classList.toggle("open");
-      toggleAriaAttributes(button);
+
+      // Single-open accordion (like pennylane-app): collapse any other open item
+      // before opening this one.
+      document.querySelectorAll(".mobile.navbar-link.open").forEach((openItem) => {
+        if (openItem === item) return;
+        const openButton = openItem.querySelector(".mobile.navbar-link-heading");
+        const openDropdown = openItem.querySelector(".mobile.navbar-dropdown");
+        if (openDropdown !== null) collapseMobileDropdown(openDropdown);
+        openItem.classList.remove("open");
+        if (openButton !== null) setAriaAttributes(openButton, false);
+      });
+
+      glideMobileAccordionToTop(item, button, dropdown);
     }
   </script>
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3170,6 +3170,12 @@ nav a:focus {
   color: #515151;
 }
 
+/* Pills gated by startDate/expiryDate are emitted hidden and revealed by JS;
+   this overrides the .navbar-pill display so the [hidden] attribute applies. */
+.navbar-pill[hidden] {
+  display: none;
+}
+
 .navbar-pill--info {
   background-color: #E6F1FC;
   color: #515151;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2067,7 +2067,17 @@ nav {
 .navbar-logo-title-container {
   display: inline-block;
   line-height: 22.5px;
-  padding: 8px 0;
+}
+
+.navbar-logo-title-container:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Prevent global link focus underlines inside the navbar. */
+nav a:focus {
+  text-decoration: none;
 }
 
 .navbar-logo-title-image {
@@ -2116,6 +2126,10 @@ nav {
   margin: 0 3px;
   gap: 4px;
   cursor: pointer;
+  /* Match pennylane-app NavItem__item border box so the focus ring insets align. */
+  border-top: 3px solid transparent;
+  border-bottom: 3px solid transparent;
+  box-sizing: border-box;
 
   color: #232323;
   font-family: 'Roboto', sans-serif;
@@ -2166,10 +2180,34 @@ nav {
 .desktop.navbar-left-link:hover > a,
 .desktop.navbar-left-link:hover > button,
 .desktop.navbar-left-link.open > a,
-.desktop.navbar-left-link.open > button {
+.desktop.navbar-left-link.open > button,
+.desktop.navbar-left-link:has(:focus-visible) > a,
+.desktop.navbar-left-link:has(:focus-visible) > button {
   color: {{ theme_border_colour }};
   transition-duration: 0.15s;
   text-decoration: none;
+}
+
+/* Nav item focus ring (mirrors pennylane-app NavItem__item:has(:focus-visible)::after). */
+.desktop.navbar-left-link:has(:focus-visible)::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  border: 2px solid #9AC7F2;
+  border-radius: 4px;
+  top: -3px;
+  left: -4px;
+  right: -4px;
+  bottom: -6px;
+  z-index: 1;
+}
+
+.desktop.navbar-left-link > a:focus-visible,
+.desktop.navbar-left-link > button:focus-visible,
+.desktop.navbar-left-link > .dropdown-trigger:focus,
+.desktop.navbar-left-link > .dropdown-trigger:focus-visible {
+  outline: none;
+  box-shadow: none;
 }
 
 .desktop.navbar-left-link a:focus:not(:focus-visible),
@@ -2180,19 +2218,15 @@ nav {
 .desktop.navbar-left-link:hover > a > i,
 .desktop.navbar-left-link:hover > button > i,
 .desktop.navbar-left-link.open > a > i,
-.desktop.navbar-left-link.open > button > i {
+.desktop.navbar-left-link.open > button > i,
+.desktop.navbar-left-link:has(:focus-visible) > a > i,
+.desktop.navbar-left-link:has(:focus-visible) > button > i {
   color: {{ theme_border_colour }};
 }
 
-.desktop.navbar-left-link.open::after {
-  background-color: {{ theme_border_colour }};
-  content: "";
-  display: block;
-  position: absolute;
-  height: 3px;
-  left: 0;
-  bottom: 0;
-  width: 100%;
+/* Open indicator uses border-bottom (mirrors pennylane-app NavItem__item.isExpanded). */
+.desktop.navbar-left-link.open {
+  border-bottom-color: {{ theme_border_colour }};
 }
 
 .desktop.navbar-left-link > ul > li > a {
@@ -2221,6 +2255,13 @@ nav {
 .desktop.navbar-right-links a {
   display: flex;
   text-decoration: none;
+}
+
+.desktop.navbar-right-link a:focus-visible,
+.desktop.navbar-right-links .desktop.navbar-button:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .desktop.navbar-right-links a i {
@@ -2432,7 +2473,9 @@ nav {
   font-weight: 400;
   line-height: 140%;
   text-decoration: none;
-  transition: all 0.15s ease;
+  outline: 2px solid transparent;
+  outline-offset: 0;
+  transition: color 0.15s ease;
 }
 
 .mega-menu-section-header__cta i {
@@ -2442,6 +2485,17 @@ nav {
 .mega-menu-section-header__cta:hover {
   color: #0055A5;
   text-decoration: none;
+}
+
+.mega-menu-section-header__cta:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.mega-menu-section-header__cta:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 0;
+  border-radius: 4px;
+  color: #0055A5;
 }
 
 .mega-menu-section-links {
@@ -2476,6 +2530,26 @@ nav {
 .mega-menu-link:hover {
   transform: translateX(3px);
   text-decoration: none;
+}
+
+.mega-menu-link:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.mega-menu-link:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.mega-menu-link:focus-visible .mega-menu-link__name,
+.mega-menu-link:focus-visible .mega-menu-link__external-icon {
+  color: #0074E0;
+}
+
+.mega-menu-link:focus-visible .mega-menu-link__description {
+  color: #232323;
 }
 
 .mega-menu-link__title {
@@ -2567,6 +2641,18 @@ nav {
   cursor: pointer;
   text-decoration: none;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+}
+
+.mega-menu-card.MenuCard:focus-visible {
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  outline: none;
+}
+
+.mega-menu-card.MenuCard:focus-visible .MenuCard__border-rect {
+  stroke: #9AC7F2;
+  stroke-dashoffset: 0;
 }
 
 .mega-menu-card.MenuCard--dark {
@@ -2799,7 +2885,8 @@ nav {
   pointer-events: none;
 }
 
-.FeaturedMenuCard--dark:hover::before {
+.FeaturedMenuCard--dark:hover::before,
+.FeaturedMenuCard--dark:focus-visible::before {
   opacity: 1;
 }
 
@@ -2893,7 +2980,17 @@ nav {
   background-color: #0055A5;
 }
 
+.FeaturedMenuCard:focus-visible .FeaturedMenuCard__button--primary {
+  background-color: #0055A5;
+}
+
 .FeaturedMenuCard:hover .FeaturedMenuCard__button--secondary {
+  background-color: #F7FAFC;
+  color: #0055A5;
+  border-color: #0055A5;
+}
+
+.FeaturedMenuCard:focus-visible .FeaturedMenuCard__button--secondary {
   background-color: #F7FAFC;
   color: #0055A5;
   border-color: #0055A5;
@@ -3110,6 +3207,12 @@ nav {
   padding: 0;
 }
 
+.mobile.navbar-menu > button:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .mobile.navbar-menu > button > i {
   color: #515151;
   font-size: 32px;
@@ -3251,11 +3354,24 @@ body.mobile-menu-open {
 .mobile.navbar-link-heading:hover i.bx-chevron-down,
 .mobile.navbar-link-heading:hover i.bx-link-external,
 .mobile.navbar-link-heading > a:hover span:not(.navbar-pill),
-.mobile.navbar-link-heading > a:hover i {
+.mobile.navbar-link-heading > a:hover i,
+.mobile.navbar-link-heading:focus-visible span:not(.navbar-pill),
+.mobile.navbar-link-heading:focus-visible i.bx-chevron-down,
+.mobile.navbar-link-heading:focus-visible i.bx-link-external,
+.mobile.navbar-link-heading > a:focus-visible span:not(.navbar-pill),
+.mobile.navbar-link-heading > a:focus-visible i {
   color: #0074E0;
 }
 
-.mobile.navbar-link-heading:focus:not(:focus-visible) {
+.mobile.navbar-link-heading:focus-visible,
+.mobile.navbar-link-heading > a:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.mobile.navbar-link-heading:focus:not(:focus-visible),
+.mobile.navbar-link-heading > a:focus:not(:focus-visible) {
   outline: none;
 }
 
@@ -3401,6 +3517,18 @@ body.mobile-menu-open {
 
 .mobile.navbar-link > .navbar-dropdown > ul > li > a:hover {
   color: #0074E0;
+}
+
+.mobile.navbar-link > .navbar-dropdown > ul > li > a:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
+  border-radius: 4px;
+  color: #0074E0;
+}
+
+.mobile.navbar-button a:focus-visible {
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
 }
 
 
@@ -5493,7 +5621,9 @@ p.sphx-glr-signature a.reference.external {
 
 .command-palette-button:hover,
 .command-palette-button:focus-visible {
-  background-color: #f1f1f1;
+  outline: 2px solid #9AC7F2;
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 .command-palette-button:focus {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3207,9 +3207,17 @@ body.mobile-menu-open {
 
 /* Mobile mega-menu typography. The shared .mega-menu-* classes carry the
    desktop sizes; React uses smaller type below $navbar-desktop-breakpoint. */
+.mobile-mega-menu .mega-menu-section-header {
+  flex-direction: column;
+  align-items: flex-start;
+  border-bottom: none;
+}
+
 .mobile-mega-menu .mega-menu-section-header__title {
   /* label-md-400 (desktop is label-lg-400 / 0.9375rem) */
   font-size: 0.875rem;
+  width: 100%;
+  border-bottom: 1px solid #CFCFCF;
 }
 
 .mobile-mega-menu .mega-menu-link__name {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -1,6 +1,6 @@
 /* Sphinx Themes
 ----------------------------------------------------------------------------- */
-@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600&family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@300;400;500;700&display=swap');
 
 body {
   margin: 0;
@@ -182,7 +182,7 @@ code {
 
 code, pre, tt {
   font-size: 14px;
-  font-family: Consolas, monospace;
+  font-family: 'Roboto Mono', Consolas, monospace;
 }
 
 code, tt, a > code {
@@ -2052,12 +2052,12 @@ nav {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 20px;
+  gap: 16px;
   background-color: white;
   box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.10), 0 10px 8px 0 rgba(0, 0, 0, 0.04);
   font-family: 'Quicksand', sans-serif !important;
   height: 50px;
-  padding: 0 16px;
+  padding: 0 20px;
   position: fixed;
   top: 0px;
   width: 100%;
@@ -2068,6 +2068,11 @@ nav {
   display: inline-block;
   line-height: 22.5px;
   padding: 8px 0;
+}
+
+.navbar-logo-title-image {
+  width: 160px;
+  height: auto;
 }
 
 .navbar-logo-title-title {
@@ -2097,8 +2102,8 @@ nav {
   flex-direction: row;
   list-style-type: none;
   margin-bottom: 0px;
+  margin-right: 64px;
   padding-left: 0px;
-  width: 100%;
 }
 
 .desktop.navbar-left-link {
@@ -2107,19 +2112,27 @@ nav {
   flex-direction: row;
   position: relative;
   height: 100%;
-  padding: 0 8px;
+  padding: 0 6px;
+  margin: 0 3px;
   gap: 4px;
 
-  color: #000;
+  color: #232323;
   font-family: 'Roboto', sans-serif;
   font-size: 16px;
-  font-weight: 400;
+  font-weight: 300;
   line-height: 150%;
 }
 
 .desktop.navbar-left-link > a,
 .desktop.navbar-left-link > button {
   color: inherit;
+  font: inherit;
+}
+
+.desktop.navbar-left-link .navbar-link__label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .desktop.navbar-left-link i.bx-chevron-down {
@@ -2131,12 +2144,12 @@ nav {
   margin-left: 8px;
 }
 
-.desktop.navbar-left-link button,
-.desktop.navbar-left-link a {
+.desktop.navbar-left-link > button,
+.desktop.navbar-left-link > a {
   display: flex;
   align-items: center;
-  gap: 4px;
-  background-color: #FFFFFF;
+  gap: 2px;
+  background-color: transparent;
   border-width: 0px;
   padding: 0;
   text-decoration: none;
@@ -2172,9 +2185,9 @@ nav {
   content: "";
   display: block;
   position: absolute;
-  height: 2.5px;
+  height: 3px;
   left: 0;
-  top: 44.5px;
+  bottom: 0;
   width: 100%;
 }
 
@@ -2190,9 +2203,10 @@ nav {
   align-items: center;
   display: flex;
   flex-direction: row;
-  gap: 8px;
+  gap: 6px;
   list-style-type: none;
   margin-bottom: 0px;
+  margin-left: auto;
 }
 
 .desktop.navbar-right-link {
@@ -2279,6 +2293,220 @@ nav {
   color: {{ theme_border_colour }};
 }
 
+/* Navigation Bar Desktop Mega Menu
+----------------------------------------------------------------------------- */
+
+.navbar-mega-menu {
+  display: none;
+  position: fixed;
+  left: 0;
+  top: 50px;
+  width: 100%;
+  z-index: 9999;
+  cursor: auto;
+  background-color: #FFFFFF;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  box-shadow:
+    inset 0 4px 3px 0 rgba(0, 0, 0, 0.07),
+    inset 0 2px 2px 0 rgba(0, 0, 0, 0.06),
+    0px 10px 8px 0px rgba(0, 0, 0, 0.04),
+    0px 4px 3px 0px rgba(0, 0, 0, 0.10);
+}
+
+.desktop.navbar-left-link.open .navbar-mega-menu {
+  display: block;
+}
+
+.navbar-mega-menu__inner {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 40px;
+  width: 100%;
+  max-width: 1535px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.navbar-mega-menu__links-area {
+  display: grid;
+  gap: 40px;
+  align-self: start;
+  grid-column: span var(--menu-link-total-columns, 1) / span var(--menu-link-total-columns, 1);
+  grid-template-columns: repeat(var(--menu-link-total-columns, 1), minmax(0, 1fr));
+  background-color: #F7FAFC;
+  height: 100%;
+  padding: 20px;
+  border-radius: 4px;
+}
+
+.navbar-mega-menu__link-section {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  align-self: start;
+}
+
+.navbar-mega-menu__section {
+  display: flex;
+  flex-direction: column;
+}
+
+.mega-menu-section-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 20px;
+  border-bottom: 1px solid #CFCFCF;
+}
+
+.mega-menu-section-header__title {
+  margin: 0;
+  padding: 6px 0;
+  color: #757575;
+  font-family: 'Roboto', sans-serif !important;
+  font-size: 0.9375rem;
+  font-weight: 400;
+  line-height: 140%;
+  text-transform: uppercase;
+}
+
+.mega-menu-section-header__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  color: #0074E0;
+  font-family: 'Roboto', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 140%;
+  text-decoration: none;
+}
+
+.mega-menu-section-header__cta i {
+  font-size: 20px;
+}
+
+.mega-menu-section-header__cta:hover {
+  color: #0055A5;
+  text-decoration: none;
+}
+
+.mega-menu-section-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.mega-menu-section-links:not(.mega-menu-section-links--multi-column) {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mega-menu-section-links--multi-column {
+  column-count: var(--link-section-columns, 2);
+  column-gap: 40px;
+}
+
+.mega-menu-section-links--multi-column > li {
+  break-inside: avoid;
+  margin-bottom: 16px;
+}
+
+.mega-menu-link {
+  display: block;
+  text-decoration: none;
+  color: #232323;
+  transition: transform 150ms ease;
+}
+
+.mega-menu-link:hover {
+  transform: translateX(3px);
+  text-decoration: none;
+}
+
+.mega-menu-link__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mega-menu-link__name {
+  color: #232323;
+  font-family: 'Roboto', sans-serif;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 150%;
+}
+
+.mega-menu-link:hover .mega-menu-link__name,
+.mega-menu-link:hover .mega-menu-link__external-icon {
+  color: #0074E0;
+}
+
+.mega-menu-link:hover .mega-menu-link__description {
+  color: #232323;
+}
+
+.mega-menu-link__external-icon {
+  color: #757575;
+  font-size: 16px;
+}
+
+.mega-menu-link__description {
+  margin: 0;
+  color: #515151;
+  font-family: 'Roboto', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 300;
+  line-height: 140%;
+}
+
+.navbar-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 20px;
+  padding: 2px 8px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 140%;
+  /* Default variant: info */
+  background-color: #E6F1FC;
+  color: #515151;
+}
+
+.navbar-pill--info {
+  background-color: #E6F1FC;
+  color: #515151;
+}
+
+.navbar-pill--in-progress {
+  background-color: #0074E0;
+  color: #FFFFFF;
+}
+
+.navbar-pill--complete {
+  background-color: #008000;
+  color: #FFFFFF;
+}
+
+.navbar-pill--partial-complete {
+  background-color: #E5F2E5;
+  color: #515151;
+}
+
+.navbar-pill--error {
+  background-color: #860000;
+  color: #FFFFFF;
+}
+
 /* Navigation Bar Mobile
 ----------------------------------------------------------------------------- */
 
@@ -2292,7 +2520,8 @@ nav {
 .mobile.navbar-menu > button {
   display: flex;
   align-items: center;
-  background-color: #FFFFFF;
+  justify-content: center;
+  background-color: transparent;
   border-width: 0px;
   padding: 0;
 }
@@ -2385,7 +2614,7 @@ nav {
   color: #515151;
 }
 
-.mobile.navbar-link-heading span {
+.mobile.navbar-link-heading span:not(.navbar-pill) {
   color: #232323;
   display: flex;
   font-family: 'Roboto', sans-serif;
@@ -2405,6 +2634,15 @@ nav {
   line-height: 28px;
   transition-duration: 0.15s;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Hover state mirrors the React Accordion / MobileMenu link (text-brand-500). */
+.mobile.navbar-link-heading:hover span:not(.navbar-pill),
+.mobile.navbar-link-heading:hover i.bx-chevron-down,
+.mobile.navbar-link-heading:hover i.bx-link-external,
+.mobile.navbar-link-heading > a:hover span:not(.navbar-pill),
+.mobile.navbar-link-heading > a:hover i {
+  color: #0074E0;
 }
 
 .mobile.navbar-link-heading:focus:not(:focus-visible) {
@@ -2451,13 +2689,44 @@ nav {
   visibility: hidden;
 }
 
-.mobile.navbar-link .navbar-dropdown ul {
+.mobile.navbar-link > .navbar-dropdown > ul {
   display: flex;
   flex-direction: column;
   list-style-type: none;
-  gap: 8px;
-  padding-inline-start: 0px;
+  gap: 16px;
+  padding: 12px;
+  border-radius: 4px;
+  background-color: #F7FAFC;
   position: relative;
+}
+
+/* Rich mega-menu content rendered inside the mobile dropdown. Mirrors the
+   React Accordion content wrapper (bg-brand-100, p-3, rounded, gap-10). */
+.mobile.navbar-link .navbar-dropdown .mobile-mega-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  padding: 12px;
+  border-radius: 4px;
+  background-color: #F7FAFC;
+}
+
+/* Mobile mega-menu typography. The shared .mega-menu-* classes carry the
+   desktop sizes; React uses smaller type below $navbar-desktop-breakpoint. */
+.mobile-mega-menu .mega-menu-section-header__title {
+  /* label-md-400 (desktop is label-lg-400 / 0.9375rem) */
+  font-size: 0.875rem;
+}
+
+.mobile-mega-menu .mega-menu-link__name {
+  /* label-lg-400 (desktop is body-sm-400 / 1rem / 150%) */
+  font-size: 0.9375rem;
+  line-height: 140%;
+}
+
+.mobile-mega-menu .mega-menu-link__description {
+  /* label-sm-300 (desktop is label-md-300 / 0.875rem) */
+  font-size: 0.75rem;
 }
 
 .mobile.navbar-link.open .navbar-dropdown {
@@ -2470,7 +2739,7 @@ nav {
   transform: rotate(180deg);
 }
 
-.mobile.navbar-dropdown a {
+.mobile.navbar-link > .navbar-dropdown > ul > li > a {
   align-items: center;
   color: #515151;
   display: flex;
@@ -2481,6 +2750,10 @@ nav {
   gap: 8px;
   line-height: 20px;
   text-decoration: none;
+}
+
+.mobile.navbar-link > .navbar-dropdown > ul > li > a:hover {
+  color: #0074E0;
 }
 
 
@@ -2500,7 +2773,9 @@ nav {
   }
 
   .mobile.navbar-links.open {
-    height: calc(100% - 50px);
+    height: calc(100% - 54px);
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     transition-delay: 0s;
     visibility: visible;
   }

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2687,10 +2687,6 @@ nav {
   background-repeat: repeat, no-repeat;
 }
 
-.mega-menu-card.FeaturedMenuCard--primary-blue {
-  min-height: 20rem;
-}
-
 /* Card button (non-interactive, styled like pennylane-app Button) */
 .FeaturedMenuCard__button {
   display: inline-flex;
@@ -3067,6 +3063,32 @@ body.mobile-menu-open {
   font-size: 0.75rem;
 }
 
+/* Section column layout (mirrors React .Accordion__content): single column on
+   narrow screens, 2 columns from the tablet breakpoint, and 3 columns from the
+   mobile-wide breakpoint when there are at least 3 sections. */
+@media screen and (min-width: 768px) {
+  .mobile.navbar-link .navbar-dropdown .mobile-mega-menu {
+    display: block;
+    column-count: 2;
+    column-gap: 40px;
+  }
+
+  .mobile-mega-menu > .navbar-mega-menu__section {
+    break-inside: avoid;
+    margin-bottom: 40px;
+  }
+
+  .mobile-mega-menu > .navbar-mega-menu__section:last-child {
+    margin-bottom: 0;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .mobile.navbar-link .navbar-dropdown .mobile-mega-menu:has(> .navbar-mega-menu__section:nth-child(3)) {
+    column-count: 3;
+  }
+}
+
 .mobile.navbar-link.open .navbar-dropdown {
   /* The height is automatically calculated in layout.html. */
   transition-delay: 0s;
@@ -3098,7 +3120,7 @@ body.mobile-menu-open {
 /* Navigation Bar Desktop and Mobile
 ----------------------------------------------------------------------------- */
 
-@media screen and (max-width: 1199px) {
+@media screen and (max-width: 1339.98px) {
   nav {
     box-shadow: 0px 4px 3px 0px rgba(0, 0, 0, 0.07), 0px 2px 2px 0px rgba(0, 0, 0, 0.06);
     height: 54px;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2142,7 +2142,6 @@ nav {
 
 .desktop.navbar-left-link i.bx-link-external {
   font-size: 16px;
-  margin-left: 8px;
 }
 
 .desktop.navbar-left-link > button,
@@ -2395,7 +2394,12 @@ nav {
 .mega-menu-section-header__cta {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
+  box-sizing: border-box;
+  height: 2rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
   white-space: nowrap;
   color: #0074E0;
   font-family: 'Roboto', sans-serif;
@@ -2403,6 +2407,7 @@ nav {
   font-weight: 400;
   line-height: 140%;
   text-decoration: none;
+  transition: all 0.15s ease;
 }
 
 .mega-menu-section-header__cta i {
@@ -2474,6 +2479,21 @@ nav {
 .mega-menu-link__external-icon {
   color: #757575;
   font-size: 16px;
+}
+
+/* Link icons (pennylane-app MenuLink__icon): brand blue, hidden on mobile,
+   shown only when the desktop mega menu is active. */
+.mega-menu-link__icon {
+  display: none;
+  flex-shrink: 0;
+  color: #0074E0;
+  font-size: 1.25rem;
+}
+
+@media screen and (min-width: 1340px) {
+  .mega-menu-link__icon {
+    display: inline-flex;
+  }
 }
 
 .mega-menu-link__description {
@@ -2603,7 +2623,7 @@ nav {
   font-family: 'Roboto', sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
-  line-height: 140%;
+  line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -2881,7 +2901,7 @@ nav {
   font-family: 'Roboto', sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
-  line-height: 140%;
+  line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2793,6 +2793,107 @@ nav {
   font-size: 20px;
 }
 
+/* Content card layout (dynamic cards populated from the content API) */
+.mega-menu-card.ContentMenuCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.ContentMenuCard__image {
+  width: 100%;
+  height: auto;
+  margin-bottom: 12px;
+  object-fit: cover;
+}
+
+.ContentMenuCard__image--no-image {
+  flex-shrink: 0;
+  aspect-ratio: 16 / 9;
+  background-color: #F5F5F5;
+}
+
+.ContentMenuCard__content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+}
+
+.ContentMenuCard__title {
+  margin: 0;
+  flex-shrink: 0;
+  color: #232323;
+  font-family: 'Quicksand', sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 140%;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.8rem;
+}
+
+.ContentMenuCard__description {
+  margin: 0;
+  flex-shrink: 0;
+  color: #232323;
+  font-family: 'Roboto', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 300;
+  line-height: 140%;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.45rem;
+}
+
+.ContentMenuCard--mobile.MenuCard {
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.ContentMenuCard--mobile .MenuCard__border-rect {
+  rx: 7px;
+}
+
+.ContentMenuCard--mobile .ContentMenuCard__image {
+  display: none;
+}
+
+.ContentMenuCard--mobile .ContentMenuCard__content {
+  gap: 4px;
+}
+
+.ContentMenuCard--mobile .ContentMenuCard__title {
+  min-height: 2.8rem;
+}
+
+.ContentMenuCard--mobile .ContentMenuCard__description {
+  font-size: 0.75rem;
+  min-height: 1.75rem;
+}
+
+/* Loading placeholder: keep the card non-interactive and show skeleton lines. */
+.content-menu-card--loading {
+  pointer-events: none;
+}
+
+.content-menu-card--loading .ContentMenuCard__title,
+.content-menu-card--loading .ContentMenuCard__description {
+  border-radius: 4px;
+  background-color: #F5F5F5;
+  color: transparent;
+}
+
+/* Empty slot (no matching item returned): keep the grid cell but hide it. */
+.content-menu-card--empty {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .navbar-pill {
   display: inline-flex;
   align-items: center;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -3098,12 +3098,33 @@ body.mobile-menu-open {
   display: flex;
   flex-direction: column;
   gap: 0px;
-  padding: 20px 0;
+  padding: 0;
   transition-duration: 350ms;
 }
 
+.mobile.navbar-link:has(.command-palette-button.mobile) {
+  padding-block: 24px 16px;
+}
+
+.mobile.navbar-links > ul > .mobile.navbar-link:has(.mobile.navbar-dropdown):not(
+  .mobile.navbar-link:has(.mobile.navbar-dropdown) ~ .mobile.navbar-link:has(.mobile.navbar-dropdown)
+) > .mobile.navbar-link-heading {
+  border-top: 1px solid #CFCFCF;
+}
+
 .mobile.navbar-link.open {
-  gap: 16px;
+  gap: 0;
+}
+
+/* Expanded accordion button sticks to the top of the scrolling mobile menu
+   (right below the navbar) until the next item scrolls up to meet it. Mirrors
+   pennylane-app's .Accordion__expanded > .Accordion_Button sticky behaviour. */
+.mobile.navbar-link.open > .mobile.navbar-link-heading {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #CFCFCF;
 }
 
 .mobile.navbar-link-heading {
@@ -3114,7 +3135,7 @@ body.mobile-menu-open {
   flex-direction: row;
   justify-content: space-between;
   padding: 0px;
-  padding-block: 0px;
+  padding-block: 20px;
   padding-inline: 0px;
   width: 100%;
 }
@@ -3286,6 +3307,9 @@ body.mobile-menu-open {
   /* The height is automatically calculated in layout.html. */
   transition-delay: 0s;
   visibility: visible;
+  /* Mirrors pennylane-app's .Accordion__content-wrapper py-4: breathing room
+     above and below the panel content relative to the sticky toggle. */
+  padding-block: 16px;
 }
 
 .mobile.navbar-link.open .navbar-link-heading i.bx-chevron-down {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2485,10 +2485,324 @@ nav {
   line-height: 140%;
 }
 
+/* Navigation Bar Mega Menu Featured Cards
+   (mirrors pennylane-app MenuCard + FeaturedMenuCard)
+----------------------------------------------------------------------------- */
+
+.navbar-mega-menu__cards-area {
+  display: grid;
+  column-gap: 40px;
+  align-self: start;
+  grid-column: span var(--menu-card-total-columns, 1) / span var(--menu-card-total-columns, 1);
+  grid-template-columns: repeat(var(--menu-card-total-columns, 1), minmax(0, 1fr));
+}
+
+.navbar-mega-menu__card-section-header {
+  margin-top: 20px;
+}
+
+/* MenuCard shell */
+.mega-menu-card.MenuCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  padding: 20px;
+  border: 1px solid #CFCFCF;
+  border-radius: 12px;
+  background-color: #FFFFFF;
+  color: #232323;
+  text-decoration: none;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.2s ease;
+}
+
+.mega-menu-card.MenuCard:hover {
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+}
+
+.mega-menu-card.MenuCard--dark {
+  border: none;
+}
+
+.mega-menu-card .MenuCard__border-svg {
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  width: calc(100% + 2px);
+  height: calc(100% + 2px);
+  fill: none;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.mega-menu-card .MenuCard__border-rect {
+  x: 1px;
+  y: 1px;
+  width: calc(100% - 2px);
+  height: calc(100% - 2px);
+  fill: none;
+  stroke-width: 2;
+  stroke-dasharray: 400;
+  stroke-dashoffset: 400;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.4s ease-in-out;
+  rx: 11px;
+}
+
+.mega-menu-card.MenuCard:hover .MenuCard__border-rect {
+  stroke: #9AC7F2;
+  stroke-dashoffset: 0;
+}
+
+/* Featured card layout */
+.FeaturedMenuCard {
+  position: relative;
+}
+
+.FeaturedMenuCard__content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+}
+
+.FeaturedMenuCard__title {
+  margin: 0;
+  font-family: 'Quicksand', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 500;
+  line-height: 120%;
+}
+
+.FeaturedMenuCard__title--truncate {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.FeaturedMenuCard__description {
+  font-family: 'Roboto', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 300;
+  line-height: 140%;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.FeaturedMenuCard__description p {
+  margin: 0;
+}
+
+.FeaturedMenuCard__image--small {
+  height: 74px;
+  width: auto;
+  object-fit: contain;
+  align-self: flex-start;
+  margin: 3px 0;
+}
+
+.FeaturedMenuCard__image--full,
+.FeaturedMenuCard__image--wide {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 4px;
+  margin: 8px 0;
+}
+
+/* Theme (text colour) */
+.FeaturedMenuCard--light .FeaturedMenuCard__title {
+  color: #232323;
+}
+
+.FeaturedMenuCard--light .FeaturedMenuCard__description,
+.FeaturedMenuCard--light .FeaturedMenuCard__description p {
+  color: #515151;
+}
+
+.FeaturedMenuCard--dark .FeaturedMenuCard__title,
+.FeaturedMenuCard--dark .FeaturedMenuCard__description,
+.FeaturedMenuCard--dark .FeaturedMenuCard__description p {
+  color: #FFFFFF;
+}
+
+/* Dark hover overlay */
+.FeaturedMenuCard--dark::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-color: rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  pointer-events: none;
+}
+
+.FeaturedMenuCard--dark:hover::before {
+  opacity: 1;
+}
+
+.FeaturedMenuCard--dark .MenuCard__border-svg {
+  z-index: 2;
+}
+
+.FeaturedMenuCard--dark > *:not(.MenuCard__border-svg) {
+  position: relative;
+  z-index: 1;
+}
+
+/* Variant backgrounds (scoped with .mega-menu-card so they out-specify the
+   base .mega-menu-card.MenuCard background/border). */
+.mega-menu-card.FeaturedMenuCard--white {
+  background-color: #FFFFFF;
+}
+
+.mega-menu-card.FeaturedMenuCard--soft-blue {
+  background-color: #E6F1FC;
+}
+
+.mega-menu-card.FeaturedMenuCard--primary-blue {
+  background-color: #0074E0;
+}
+
+.mega-menu-card.FeaturedMenuCard--dark-blue {
+  background-color: #0055A5;
+}
+
+.mega-menu-card.FeaturedMenuCard--confetti {
+  background: #FFFFFF url('https://assets.cloud.pennylane.ai/pennylane_website/backgrounds/navbar-menu-card-confetti.png') no-repeat top right;
+  background-size: contain;
+}
+
+.mega-menu-card.FeaturedMenuCard--dark-gradient {
+  background: url('https://assets.cloud.pennylane.ai/pennylane_website/backgrounds/pennylane-background-tile.png'), linear-gradient(to right, #12274A, #115E97);
+  background-size: 291px 80px, 100% 100%;
+  background-repeat: repeat, no-repeat;
+}
+
+.mega-menu-card.FeaturedMenuCard--primary-blue {
+  min-height: 20rem;
+}
+
+/* Card button (non-interactive, styled like pennylane-app Button) */
+.FeaturedMenuCard__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  margin-top: auto;
+  width: 100%;
+  height: 2.5rem;
+  padding: 0 20px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 400;
+  line-height: 140%;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+/* Desktop card pills use the Pill "small" size (px-3 py-1); mobile uses "xs". */
+.FeaturedMenuCard--desktop .navbar-pill {
+  padding: 4px 12px;
+}
+
+.FeaturedMenuCard__button-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.FeaturedMenuCard__button i {
+  font-size: 22px;
+}
+
+.FeaturedMenuCard__button--primary {
+  background-color: #0074E0;
+  color: #FFFFFF;
+  border-color: transparent;
+}
+
+.FeaturedMenuCard__button--secondary {
+  background-color: #FFFFFF;
+  color: #0074E0;
+  border-color: #0074E0;
+}
+
+.FeaturedMenuCard:hover .FeaturedMenuCard__button--primary {
+  background-color: #0055A5;
+}
+
+.FeaturedMenuCard:hover .FeaturedMenuCard__button--secondary {
+  background-color: #F7FAFC;
+  color: #0055A5;
+  border-color: #0055A5;
+}
+
+/* Mobile featured cards */
+.mobile-mega-menu .MobileMenu__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 330px;
+}
+
+.FeaturedMenuCard--mobile.MenuCard {
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.FeaturedMenuCard--mobile .MenuCard__border-rect {
+  rx: 7px;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__content {
+  gap: 4px;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__title {
+  font-size: 1rem;
+  line-height: 140%;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__description {
+  font-size: 0.75rem;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__image {
+  display: none;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__button {
+  height: 2rem;
+  padding: 0 12px;
+  font-size: 0.875rem;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__button-label {
+  gap: 8px;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__button i {
+  font-size: 20px;
+}
+
 .navbar-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: fit-content;
+  box-sizing: border-box;
   white-space: nowrap;
   border-radius: 20px;
   padding: 2px 8px;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2301,7 +2301,17 @@ nav {
 ----------------------------------------------------------------------------- */
 
 .navbar-mega-menu {
-  display: none;
+  /* Slide-down animation mirrors pennylane-app's .MegaMenu__container: the
+     container is a single-row grid that animates grid-template-rows 0fr -> 1fr
+     (height) together with opacity. The inner .navbar-mega-menu__overflow wrapper
+     has overflow: hidden so the content is clipped as the row collapses. */
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    grid-template-rows 0.45s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.45s cubic-bezier(0.4, 0, 0.2, 1);
   position: fixed;
   left: 0;
   top: 50px;
@@ -2318,8 +2328,23 @@ nav {
     0px 4px 3px 0px rgba(0, 0, 0, 0.10);
 }
 
+.navbar-mega-menu__overflow {
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* Wrapper whose explicit pixel height is animated by JS when switching between
+   two already-open mega menus (mirrors pennylane-app's .MegaMenu__resize). When
+   no inline height is set it stays auto, so the open/close grid animation above
+   drives the reveal instead. */
+.navbar-mega-menu__resize {
+  transition: height 0.45s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 .desktop.navbar-left-link.open .navbar-mega-menu {
-  display: block;
+  grid-template-rows: 1fr;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* Dimmed backdrop behind an open mega menu (matches pennylane-app's

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2115,6 +2115,7 @@ nav {
   padding: 0 6px;
   margin: 0 3px;
   gap: 4px;
+  cursor: pointer;
 
   color: #232323;
   font-family: 'Roboto', sans-serif;
@@ -2163,8 +2164,10 @@ nav {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.desktop.navbar-left-link a:hover,
-.desktop.navbar-left-link button:hover {
+.desktop.navbar-left-link:hover > a,
+.desktop.navbar-left-link:hover > button,
+.desktop.navbar-left-link.open > a,
+.desktop.navbar-left-link.open > button {
   color: {{ theme_border_colour }};
   transition-duration: 0.15s;
   text-decoration: none;
@@ -2176,11 +2179,13 @@ nav {
 }
 
 .desktop.navbar-left-link:hover > a > i,
-.desktop.navbar-left-link:hover > button > i {
+.desktop.navbar-left-link:hover > button > i,
+.desktop.navbar-left-link.open > a > i,
+.desktop.navbar-left-link.open > button > i {
   color: {{ theme_border_colour }};
 }
 
-.desktop.navbar-left-link:hover::after {
+.desktop.navbar-left-link.open::after {
   background-color: {{ theme_border_colour }};
   content: "";
   display: block;
@@ -2315,6 +2320,20 @@ nav {
 }
 
 .desktop.navbar-left-link.open .navbar-mega-menu {
+  display: block;
+}
+
+/* Dimmed backdrop behind an open mega menu (matches pennylane-app's
+   .Navbar__overlay: fixed, rgba(0,0,0,0.1), below the navbar/mega menu). */
+.navbar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 9990;
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.navbar-overlay.open {
   display: block;
 }
 
@@ -2530,6 +2549,11 @@ nav {
   color: #515151;
   font-size: 32px;
   font-weight: 400;
+}
+
+/* Prevent the page behind the mobile menu from scrolling while it is open. */
+body.mobile-menu-open {
+  overflow: hidden;
 }
 
 .mobile.navbar-menu > button > i.bx-x {

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2491,6 +2491,13 @@ nav a:focus {
   outline: none;
 }
 
+/* The v2 "text" Button has no underline; override the global nav link focus
+   underline so the focused CTA shows only the ring. */
+.mega-menu-section-header__cta:focus,
+.mega-menu-section-header__cta:focus-visible {
+  text-decoration: none;
+}
+
 .mega-menu-section-header__cta:focus-visible {
   outline: 2px solid #9AC7F2;
   outline-offset: 0;
@@ -3366,7 +3373,6 @@ body.mobile-menu-open {
 .mobile.navbar-link-heading:focus-visible,
 .mobile.navbar-link-heading > a:focus-visible {
   outline: 2px solid #9AC7F2;
-  outline-offset: 2px;
   border-radius: 4px;
 }
 

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2585,6 +2585,20 @@ nav {
   overflow: hidden;
 }
 
+.FeaturedMenuCard__title--clamp-4 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  height: fit-content;
+  max-height: 7.2rem;
+}
+
+.FeaturedMenuCard--mobile .FeaturedMenuCard__title--clamp-4 {
+  height: fit-content;
+  max-height: 5.6rem;
+}
+
 .FeaturedMenuCard__description {
   font-family: 'Roboto', sans-serif;
   font-size: 0.875rem;
@@ -2615,6 +2629,31 @@ nav {
   object-fit: cover;
   border-radius: 4px;
   margin: 8px 0;
+}
+
+/* Placeholder shown for a "full" image card while the release card loads its
+   thumbnail (pennylane-app FeaturedMenuCard__image--placeholder: bg-secondary). */
+.FeaturedMenuCard__image--placeholder {
+  flex-shrink: 0;
+  aspect-ratio: 16 / 9;
+  background-color: #F5F5F5;
+}
+
+/* Release card loading state: non-interactive with a skeleton title line. */
+.release-menu-card--loading {
+  pointer-events: none;
+}
+
+.release-menu-card--loading .FeaturedMenuCard__title {
+  border-radius: 4px;
+  background-color: rgba(255, 255, 255, 0.25);
+  min-height: 1.4em;
+}
+
+/* Empty slot (no release returned): keep the grid cell but hide it. */
+.release-menu-card--empty {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 /* Theme (text colour) */

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2741,7 +2741,7 @@ nav a:focus {
   font-family: 'Roboto', sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
-  line-height: 1.5;
+  line-height: 140%;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -2835,7 +2835,6 @@ nav a:focus {
 }
 
 .ReleaseMenuCardSkeleton--desktop {
-  min-height: 20rem;
   padding: 20px;
   border-radius: 12px;
 }
@@ -2967,7 +2966,7 @@ nav a:focus {
   gap: 12px;
 }
 
-.FeaturedMenuCard__button i {
+.desktop.navbar-left-link .FeaturedMenuCard__button i {
   font-size: 22px;
 }
 
@@ -3100,7 +3099,7 @@ nav a:focus {
   font-family: 'Roboto', sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
-  line-height: 1.5;
+  line-height: 140%;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;

--- a/xanadu_sphinx_theme/static/xanadu.css_t
+++ b/xanadu_sphinx_theme/static/xanadu.css_t
@@ -2684,15 +2684,85 @@ nav {
   background-color: #F5F5F5;
 }
 
-/* Release card loading state: non-interactive with a skeleton title line. */
-.release-menu-card--loading {
+.ReleaseMenuCardSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  border: 1px solid #CFCFCF;
+  border-radius: 12px;
+  background-color: #0074E0;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
   pointer-events: none;
 }
 
-.release-menu-card--loading .FeaturedMenuCard__title {
+.ReleaseMenuCardSkeleton__title-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: auto;
+}
+
+.ReleaseMenuCardSkeleton__title {
+  width: 100%;
+  height: 25px;
+  border-radius: 20px;
+  background-color: #0055A5;
+}
+
+.ReleaseMenuCardSkeleton__title-first-line {
+  width: 50%;
+}
+
+.ReleaseMenuCardSkeleton__title-second-line {
+  width: 80%;
+}
+
+.ReleaseMenuCardSkeleton__title-third-line {
+  width: 100%;
+}
+
+.ReleaseMenuCardSkeleton__title-fourth-line {
+  width: 60%;
+}
+
+.ReleaseMenuCardSkeleton__image {
+  width: 100%;
+  height: 100px;
+  margin-block: 8px;
   border-radius: 4px;
-  background-color: rgba(255, 255, 255, 0.25);
-  min-height: 1.4em;
+  background-color: #0055A5;
+}
+
+.ReleaseMenuCardSkeleton__button {
+  width: 100%;
+  height: 2.5rem;
+  border-radius: 4px;
+  background-color: #0055A5;
+}
+
+.ReleaseMenuCardSkeleton--desktop {
+  min-height: 20rem;
+  padding: 20px;
+  border-radius: 12px;
+}
+
+.ReleaseMenuCardSkeleton--mobile {
+  gap: 4px;
+  padding: 12px;
+  border-radius: 8px;
+}
+
+.ReleaseMenuCardSkeleton--mobile .ReleaseMenuCardSkeleton__title-container {
+  margin-bottom: 12px;
+}
+
+.ReleaseMenuCardSkeleton--mobile .ReleaseMenuCardSkeleton__image {
+  display: none;
+}
+
+.ReleaseMenuCardSkeleton--mobile .ReleaseMenuCardSkeleton__button {
+  height: 2rem;
 }
 
 /* Empty slot (no release returned): keep the grid cell but hide it. */


### PR DESCRIPTION
**Context:** Port the new global `navbar` to sphinx documentation

**Description of the Change:** 

https://github.com/user-attachments/assets/f0fb91a9-2723-4ef2-ba1e-cdd2add9617e


https://github.com/user-attachments/assets/cba6d360-4fdc-4140-a945-d9bbbc462cc9


- Ported PennyLane's new global mega-menu `navbar` into the Sphinx theme.
  - On desktop it expands into a "mega menu" with multi-column sections and a slide-down animation.
  - On mobile it collapses into an accordion with expand/collapse animations.
  - Menus render featured cards along with content and latest-release cards.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
